### PR TITLE
feat: support idForwarding feature toggle

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       # - GF_AUTH_DISABLE_LOGIN_FORM=true
       # We need to toggle external service accounts so that Grafana will get
       # the token from a service account to read dashboards
-      - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-externalServiceAccounts}
+      - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-idForwarding,externalServiceAccounts}
       # disable alerting because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -69,14 +69,19 @@ func (c *Config) String() string {
 		appURL = c.AppURL
 	}
 
+	token := "unset"
+	if c.Token != "" {
+		token = "set"
+	}
+
 	return fmt.Sprintf(
 		"Theme: %s; Orientation: %s; Layout: %s; Dashboard Mode: %s; Time Zone: %s; Encoded Logo: %s; "+
 			"Max Renderer Workers: %d; Max Browser Workers: %d; Remote Chrome Addr: %s; App URL: %s; "+
-			"TLS Skip verifiy: %v; Included Panel IDs: %s; Excluded Panel IDs: %s",
+			"TLS Skip verifiy: %v; Included Panel IDs: %s; Excluded Panel IDs: %s; Token: %s",
 		c.Theme, c.Orientation, c.Layout,
 		c.DashboardMode, c.TimeZone, encodedLogo, c.MaxRenderWorkers, c.MaxBrowserWorkers,
 		c.RemoteChromeURL, appURL,
-		c.SkipTLSCheck, includedPanelIDs, excludedPanelIDs,
+		c.SkipTLSCheck, includedPanelIDs, excludedPanelIDs, token,
 	)
 }
 

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -178,13 +178,6 @@ func (app *App) handleReport(w http.ResponseWriter, req *http.Request) {
 			HeaderName:  GrafanaUserSignInTokenHeaderName,
 			HeaderValue: req.Header.Get(GrafanaUserSignInTokenHeaderName),
 		}
-	case req.Header.Get(backend.OAuthIdentityTokenHeaderName) != "":
-		ctxLogger.Debug("using OAuth identity token")
-
-		credential = client.Credential{
-			HeaderName:  backend.OAuthIdentityTokenHeaderName,
-			HeaderValue: req.Header.Get(backend.OAuthIdentityTokenHeaderName),
-		}
 	// This case is irrevelant starting from Grafana 10.4.4.
 	// This commit https://github.com/grafana/grafana/commit/56a4af87d706087ea42780a79f8043df1b5bc3ea
 	// made changes to not forward the cookies to app plugins.

--- a/tests/appConfig.spec.ts
+++ b/tests/appConfig.spec.ts
@@ -21,7 +21,7 @@ test("should be possible to save app configuration", async ({
   // enter some valid values
   await page
     .getByRole("textbox", { name: "Service Account Token" })
-    .fill("secret-api-key");
+    .fill("");
   await page.getByLabel("Grid").click();
   await page.getByLabel("Expand section Additional Settings").click();
   await page.getByLabel("Maximum Render Workers").clear();


### PR DESCRIPTION
Fixes #73 

This PR add support for the idForwarding feature toggle in Grafana. It restores the old behavior back that a identity of an user can be used to fetch dashboard data. This mitigrate any RBAC breakout issues.

If idForwarding, Grafana issue an JWT Token for the logged-in user and [set it to `X-Grafana-Id` header](https://github.com/grafana/grafana/blob/24c9aad5bba353a6d53798a051187252d576efe2/pkg/services/pluginsintegration/clientmiddleware/forward_id_middleware.go#L40). The JWT token can be re-used for request against Grafana. In such scenarios, the externalServiceAccounts is not needed.

The feature is availible since [Grafana 10.3](https://github.com/grafana/grafana/pull/79358)
