### PR TITLE
Update plugin backend to work with Grafana v11.3.0

### DIFF
--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       context: ../.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.1.0}
+        grafana_version: ${GRAFANA_VERSION:-11.3.0}
     ports:
       - 3080:${GF_SERVER_HTTP_PORT:-3000}/tcp
     volumes:
@@ -35,6 +35,7 @@ services:
       # We need to toggle external service accounts so that Grafana will get
       # the token from a service account to read dashboards
       - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-accessControlOnCall,idForwarding,externalServiceAccounts}
+      - GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED=true
       # disable alerting because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false
@@ -71,7 +72,7 @@ services:
       context: ../.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.1.0}
+        grafana_version: ${GRAFANA_VERSION:-11.3.0}
     ports:
       - 3443:${GF_SERVER_HTTP_PORT:-3000}/tcp
     volumes:
@@ -96,6 +97,7 @@ services:
       # We need to toggle external service accounts so that Grafana will get
       # the token from a service account to read dashboards
       - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-accessControlOnCall,idForwarding,externalServiceAccounts}
+      - GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED=true
       # disable alerting because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false

--- a/.github/workflows/step_e2e-tests.yml
+++ b/.github/workflows/step_e2e-tests.yml
@@ -36,12 +36,19 @@ jobs:
             # snapshots-folder: remote-chrome
             name: remote-chrome-10.4.7-without-features
 
-          # Latest Grafana with remote chrome
+          # Grafana v11 with remote chrome
           - grafana-version: 11.1.0
             remote-chrome-url: ws://localhost:9222
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
             # snapshots-folder: remote-chrome
             name: remote-chrome-11.1.0-with-features
+
+          # Latest Grafana with local chrome
+          - grafana-version: 11.3.0
+            remote-chrome-url: ws://localhost:9222
+            feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            # snapshots-folder: remote-chrome
+            name: local-chrome-11.3.0-with-features
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ plugin-validator
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# Ignore debugging screenshots
+*.png

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.2.0}
+        grafana_version: ${GRAFANA_VERSION:-11.3.0}
         development: ${DEVELOPMENT:-false}
     cap_add:
       - SYS_PTRACE
@@ -29,7 +29,7 @@ services:
       - GF_LOG_LEVEL=${GF_LOG_LEVEL:-info}
       - GF_DATAPROXY_LOGGING=true
       # allow anonymous admin so we don't have to set up a password to start testing
-      - GF_AUTH_ANONYMOUS_ENABLED=${GF_AUTH_ANONYMOUS_ENABLED:-true}
+      - GF_AUTH_ANONYMOUS_ENABLED=${GF_AUTH_ANONYMOUS_ENABLED:-false}
       - GF_AUTH_LOGIN_COOKIE_NAME=${GF_AUTH_LOGIN_COOKIE_NAME:-grafana_session}
       - GF_AUTH_BASIC_ENABLED=${GF_AUTH_BASIC_ENABLED:-false}
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
@@ -38,6 +38,7 @@ services:
       # We need to toggle external service accounts so that Grafana will get
       # the token from a service account to read dashboards
       - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-accessControlOnCall,idForwarding,externalServiceAccounts}
+      - GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED=${GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED:-true}
       # disable alerting because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mahendrapaipuri-dashboardreporter-app",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "A Grafana plugin app that generates PDF reports from Grafana dashboards",
   "config": {
     "plainUrl": "http://admin:admin@localhost:3080/api/plugins/mahendrapaipuri-dashboardreporter-app/resources/report?dashUid=fdlwjnyim1la8f&layout=simple&orientation=portrait&dashboardMode=default&var-testvar0=All&var-testvar1=foo&var-testvar2=1",

--- a/pkg/plugin/client/client_test.go
+++ b/pkg/plugin/client/client_test.go
@@ -93,6 +93,7 @@ func TestGrafanaClientFetchesDashboardWithLocalChrome(t *testing.T) {
 				chromeInstance,
 				workerPools,
 				ts.URL,
+				"v11.1.0",
 				credential,
 				url.Values{},
 			)
@@ -165,6 +166,7 @@ func TestGrafanaClientFetchesDashboardWithRemoteChrome(t *testing.T) {
 				chromeInstance,
 				workerPools,
 				ts.URL,
+				"v11.1.0",
 				credential,
 				url.Values{},
 			)
@@ -215,7 +217,7 @@ func TestGrafanaClientFetchesPanelPNG(t *testing.T) {
 			pngEndpoint string
 		}{
 			"httpClient": {
-				New(log.NewNullLogger(), conf, http.DefaultClient, nil, workerPools, ts.URL, credential, variables),
+				New(log.NewNullLogger(), conf, http.DefaultClient, nil, workerPools, ts.URL, "v11.1.0", credential, variables),
 				"/render/d-solo/testDash/_",
 			},
 		}
@@ -223,7 +225,7 @@ func TestGrafanaClientFetchesPanelPNG(t *testing.T) {
 			grf := cl.client
 			_, err := grf.PanelPNG(
 				context.Background(), "testDash",
-				dashboard.Panel{ID: 44, Type: "singlestat", Title: "title", GridPos: dashboard.GridPos{}},
+				dashboard.Panel{ID: "44", Type: "singlestat", Title: "title", GridPos: dashboard.GridPos{}},
 				dashboard.TimeRange{From: "now-1h", To: "now"},
 			)
 
@@ -266,7 +268,7 @@ func TestGrafanaClientFetchesPanelPNG(t *testing.T) {
 			pngEndpoint string
 		}{
 			"httpClient": {
-				New(log.NewNullLogger(), conf, http.DefaultClient, nil, workerPools, ts.URL, credential, variables),
+				New(log.NewNullLogger(), conf, http.DefaultClient, nil, workerPools, ts.URL, "v11.1.0", credential, variables),
 				"/render/d-solo/testDash/_",
 			},
 		}
@@ -275,7 +277,7 @@ func TestGrafanaClientFetchesPanelPNG(t *testing.T) {
 
 			Convey("The httpClient should request grid layout panels with width=2400 and height=216", func() {
 				_, err := grf.PanelPNG(context.Background(), "testDash",
-					dashboard.Panel{ID: 44, Type: "graph", Title: "title", GridPos: dashboard.GridPos{H: 6, W: 24}},
+					dashboard.Panel{ID: "44", Type: "graph", Title: "title", GridPos: dashboard.GridPos{H: 6, W: 24}},
 					dashboard.TimeRange{From: "now", To: "now-1h"},
 				)
 
@@ -313,12 +315,13 @@ func TestGrafanaClientFetchPanelPNGErrorHandling(t *testing.T) {
 			nil,
 			workerPools,
 			ts.URL,
+			"v11.1.0",
 			Credential{},
 			url.Values{},
 		)
 
 		_, err := grf.PanelPNG(context.Background(), "testDash",
-			dashboard.Panel{ID: 44, Type: "singlestat", Title: "title", GridPos: dashboard.GridPos{}},
+			dashboard.Panel{ID: "44", Type: "singlestat", Title: "title", GridPos: dashboard.GridPos{}},
 			dashboard.TimeRange{From: "now-1h", To: "now"},
 		)
 
@@ -345,12 +348,13 @@ func TestGrafanaClientFetchPanelPNGErrorHandling(t *testing.T) {
 			nil,
 			workerPools,
 			ts.URL,
+			"v11.1.0",
 			Credential{},
 			url.Values{},
 		)
 
 		_, err := grf.PanelPNG(context.Background(), "testDash",
-			dashboard.Panel{ID: 44, Type: "singlestat", Title: "title", GridPos: dashboard.GridPos{}},
+			dashboard.Panel{ID: "44", Type: "singlestat", Title: "title", GridPos: dashboard.GridPos{}},
 			dashboard.TimeRange{From: "now-1h", To: "now"},
 		)
 

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -29,9 +28,9 @@ type Config struct {
 	MaxBrowserWorkers   int    `env:"GF_REPORTER_PLUGIN_MAX_BROWSER_WORKERS, overwrite"    json:"maxBrowserWorkers"`
 	MaxRenderWorkers    int    `env:"GF_REPORTER_PLUGIN_MAX_RENDER_WORKERS, overwrite"     json:"maxRenderWorkers"`
 	RemoteChromeURL     string `env:"GF_REPORTER_PLUGIN_REMOTE_CHROME_URL, overwrite"      json:"remoteChromeUrl"`
-	IncludePanelIDs     []int
-	ExcludePanelIDs     []int
-	IncludePanelDataIDs []int
+	IncludePanelIDs     []string
+	ExcludePanelIDs     []string
+	IncludePanelDataIDs []string
 
 	// HTTP Client
 	HTTPClientOptions httpclient.Options
@@ -50,34 +49,19 @@ func (c *Config) String() string {
 	includedPanelIDs := "all"
 
 	if len(c.IncludePanelIDs) > 0 {
-		panelIDs := make([]string, len(c.IncludePanelIDs))
-		for index, id := range c.IncludePanelIDs {
-			panelIDs[index] = strconv.Itoa(id)
-		}
-
-		includedPanelIDs = strings.Join(panelIDs, ",")
+		includedPanelIDs = strings.Join(c.IncludePanelIDs, ",")
 	}
 
 	excludedPanelIDs := "none"
 
 	if len(c.ExcludePanelIDs) > 0 {
-		panelIDs := make([]string, len(c.ExcludePanelIDs))
-		for index, id := range c.ExcludePanelIDs {
-			panelIDs[index] = strconv.Itoa(id)
-		}
-
-		excludedPanelIDs = strings.Join(panelIDs, ",")
+		excludedPanelIDs = strings.Join(c.ExcludePanelIDs, ",")
 	}
 
 	includeDataPanelIDs := "none"
 
 	if len(c.IncludePanelDataIDs) > 0 {
-		panelIDs := make([]string, len(c.IncludePanelDataIDs))
-		for index, id := range c.IncludePanelDataIDs {
-			panelIDs[index] = strconv.Itoa(id)
-		}
-
-		includeDataPanelIDs = strings.Join(panelIDs, ",")
+		includeDataPanelIDs = strings.Join(c.IncludePanelDataIDs, ",")
 	}
 
 	appURL := "unset"

--- a/src/README.md
+++ b/src/README.md
@@ -104,6 +104,17 @@ The plugin can work without enabling any of the above feature flags for `Grafana
 However, for `Grafana > 10.4.4`, feature `externalServiceAccounts` must be enabled for
 the plugin to work.
 
+> [!IMPORTANT]
+> From Grafana v11.3.0+, to use `externalServiceAccounts` feature, the following configuration
+must be added to `auth` section of Grafana.
+
+```ini
+[auth]
+managed_service_accounts_enabled = true
+```
+
+More details can be found in Grafana [docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#managed_service_accounts_enabled)
+
 ### Install with Docker-compose
 
 There is a docker compose file provided in the repo. Create a directory `dist` in the

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -4,8 +4,11 @@ import { ROUTES } from "../src/constants";
 
 test.describe("navigating app", () => {
   test("Status should render successfully", async ({ gotoPage, page }) => {
+    // Seems like plugin page takes a while to load in Grafana v11.3.0+
+    test.setTimeout(10000);
+    
     await gotoPage(`/${ROUTES.Status}`);
-    await expect(page.getByText("Plugin Health Check")).toBeVisible();
+    await expect(page.getByText("Plugin Health Check")).toBeVisible({timeout: 5000});
     await expect(page.getByTestId(testIds.Status.health)).toContainText("OK");
   });
 });


### PR DESCRIPTION
* There have been few changes in frontend of Grafana v11.3.0. Firstly, the panels are being lazily loaded. Thus we need to wait for the panels to load entirely before running our JS to fetch panels data.

* Panel ID scheme has also changed. Before repeated panels used to have integer IDs started from largest ID of the dashboard. Now, the naming is with `panel-` prefix and repeated panels will have `clone-[\d+]` suffix to indicate number of clones.

* These two breaking changes have been incorporated into plugin backend to make it work across Grafana versions. Tested on 10.3.0, 11.2.2 and 11.3.0

* Fixed broken CSV table generation for Grafana v10.x

* Updated docs with necessary config that has been added to Grafana v11.3.0

Closes #146 