### PR TITLE
Configurable time format and time related bugfixes

### DIFF
--- a/.github/workflows/step_build.yml
+++ b/.github/workflows/step_build.yml
@@ -40,10 +40,10 @@ jobs:
             echo "has-backend=true" >> $GITHUB_OUTPUT
           fi
 
-      # Install chrome as we will use it in e2e tests
-      - uses: browser-actions/setup-chrome@v1
-        with:
-          install-dependencies: true
+      # # Install chrome as we will use it in e2e tests
+      # - uses: browser-actions/setup-chrome@v1
+      #   with:
+      #     install-dependencies: true
 
       # Install chrome manually until the upstream action
       # fixes it for latest ubuntu

--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -72,6 +72,13 @@ func NewDashboardReporterApp(ctx context.Context, settings backend.AppInstanceSe
 		return nil, fmt.Errorf("error loading config: %w", err)
 	}
 
+	// Validate plugin config
+	if err := app.conf.Validate(); err != nil {
+		app.ctxLogger.Error("error config validation", "err", err)
+
+		return nil, fmt.Errorf("error config validation: %w", err)
+	}
+
 	app.ctxLogger.Info("starting plugin with initial config: " + app.conf.String())
 
 	// Make a new HTTP client

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -425,6 +425,7 @@ func (g GrafanaClient) getPanelPNGURL(p dashboard.Panel, dashUID string, t dashb
 	values.Add("panelId", p.ID)
 	values.Add("from", t.From)
 	values.Add("to", t.To)
+
 	if g.conf.TimeZone != "" {
 		values.Add("timezone", g.conf.TimeZone)
 	}

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -425,6 +425,9 @@ func (g GrafanaClient) getPanelPNGURL(p dashboard.Panel, dashUID string, t dashb
 	values.Add("panelId", p.ID)
 	values.Add("from", t.From)
 	values.Add("to", t.To)
+	if g.conf.TimeZone != "" {
+		values.Add("timezone", g.conf.TimeZone)
+	}
 
 	// If using a grid layout we use 100px for width and 36px for height scaling.
 	// Grafana panels are fitted into 24 units width and height units are said to

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -46,7 +46,7 @@ type Config struct {
 	IncludePanelDataIDs []string
 
 	// Time location
-	TimeLocation *time.Location
+	Location *time.Location
 
 	// HTTP Client
 	HTTPClientOptions httpclient.Options
@@ -79,10 +79,10 @@ func (c *Config) Validate() error {
 
 	// Set time zone to current server time zone if empty
 	if loc, err := time.LoadLocation(c.TimeZone); err != nil || c.TimeZone == "" {
-		c.TimeLocation = time.Now().Local().Location()
-		c.TimeZone = c.TimeLocation.String()
+		c.Location = time.Now().Local().Location()
+		c.TimeZone = c.Location.String()
 	} else {
-		c.TimeLocation = loc
+		c.Location = loc
 		c.TimeZone = loc.String()
 	}
 

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
@@ -22,6 +23,7 @@ type Config struct {
 	Layout              string `env:"GF_REPORTER_PLUGIN_REPORT_LAYOUT, overwrite"          json:"layout"`
 	DashboardMode       string `env:"GF_REPORTER_PLUGIN_REPORT_DASHBOARD_MODE, overwrite"  json:"dashboardMode"`
 	TimeZone            string `env:"GF_REPORTER_PLUGIN_REPORT_TIMEZONE, overwrite"        json:"timeZone"`
+	TimeFormat          string `env:"GF_REPORTER_PLUGIN_REPORT_TIMEFORMAT, overwrite"      json:"timeFormat"`
 	EncodedLogo         string `env:"GF_REPORTER_PLUGIN_REPORT_LOGO, overwrite"            json:"logo"`
 	HeaderTemplate      string `env:"GF_REPORTER_PLUGIN_REPORT_HEADER_TEMPLATE, overwrite" json:"headerTemplate"`
 	FooterTemplate      string `env:"GF_REPORTER_PLUGIN_REPORT_FOOTER_TEMPLATE, overwrite" json:"footerTemplate"`
@@ -71,10 +73,10 @@ func (c *Config) String() string {
 
 	return fmt.Sprintf(
 		"Theme: %s; Orientation: %s; Layout: %s; Dashboard Mode: %s; "+
-			"Time Zone: %s; Encoded Logo: %s; "+
+			"Time Zone: %s; Time Format: %s; Encoded Logo: %s; "+
 			"Max Renderer Workers: %d; Max Browser Workers: %d; Remote Chrome Addr: %s; App URL: %s; "+
 			"TLS Skip verify: %v; Included Panel IDs: %s; Excluded Panel IDs: %s Included Data for Panel IDs: %s",
-		c.Theme, c.Orientation, c.Layout, c.DashboardMode, c.TimeZone,
+		c.Theme, c.Orientation, c.Layout, c.DashboardMode, c.TimeZone, c.TimeFormat,
 		encodedLogo, c.MaxRenderWorkers, c.MaxBrowserWorkers, c.RemoteChromeURL, appURL,
 		c.SkipTLSCheck, includedPanelIDs, excludedPanelIDs, includeDataPanelIDs,
 	)
@@ -90,6 +92,7 @@ func Load(ctx context.Context, settings backend.AppInstanceSettings) (Config, er
 		Layout:            "simple",
 		DashboardMode:     "default",
 		TimeZone:          "",
+		TimeFormat:        time.UnixDate,
 		EncodedLogo:       "",
 		HeaderTemplate:    "",
 		FooterTemplate:    "",

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -13,6 +16,14 @@ import (
 )
 
 const SaToken = "saToken"
+
+// Valid setting parameters.
+var (
+	validThemes       = []string{"light", "dark"}
+	validLayouts      = []string{"simple", "grid"}
+	validOrientations = []string{"portrait", "landscape"}
+	validModes        = []string{"default", "full"}
+)
 
 // Config contains plugin settings.
 type Config struct {
@@ -34,11 +45,66 @@ type Config struct {
 	ExcludePanelIDs     []string
 	IncludePanelDataIDs []string
 
+	// Time location
+	TimeLocation *time.Location
+
 	// HTTP Client
 	HTTPClientOptions httpclient.Options
 
 	// Secrets
 	Token string
+}
+
+// Validate checks current settings and sets them to defaults for invalid ones.
+func (c *Config) Validate() error {
+	// Check theme
+	if !slices.Contains(validThemes, c.Theme) {
+		return fmt.Errorf("theme: %s must be one of [%s]", c.Theme, strings.Join(validThemes, ","))
+	}
+
+	// Check layout
+	if !slices.Contains(validLayouts, c.Layout) {
+		return fmt.Errorf("layout: %s must be one of [%s]", c.Layout, strings.Join(validLayouts, ","))
+	}
+
+	// Check Orientation
+	if !slices.Contains(validOrientations, c.Orientation) {
+		return fmt.Errorf("orientation: %s must be one of [%s]", c.Orientation, strings.Join(validOrientations, ","))
+	}
+
+	// Check Mode
+	if !slices.Contains(validModes, c.DashboardMode) {
+		return fmt.Errorf("dashboard mode: %s must be one of [%s]", c.DashboardMode, strings.Join(validModes, ","))
+	}
+
+	// Set time zone to current server time zone if empty
+	if loc, err := time.LoadLocation(c.TimeZone); err != nil || c.TimeZone == "" {
+		c.TimeLocation = time.Now().Local().Location()
+		c.TimeZone = c.TimeLocation.String()
+	} else {
+		c.TimeLocation = loc
+		c.TimeZone = loc.String()
+	}
+
+	// Set time format to time.UnixDate if the provided one is invalid
+	t := time.Now().Format(c.TimeFormat)
+	if parsedTime, err := time.Parse(c.TimeFormat, t); err != nil || parsedTime.Unix() <= 0 {
+		c.TimeFormat = time.UnixDate
+	}
+
+	// Verify RemoteChromeURL
+	// url.Parse almost allows all the URLs. Need to check Scheme and Host
+	if c.RemoteChromeURL != "" {
+		if u, err := url.Parse(c.RemoteChromeURL); err != nil {
+			return err
+		} else {
+			if u.Scheme == "" || u.Host == "" {
+				return errors.New("remote chrome url is invalid")
+			}
+		}
+	}
+
+	return nil
 }
 
 // String implements the stringer interface of Config.
@@ -92,7 +158,7 @@ func Load(ctx context.Context, settings backend.AppInstanceSettings) (Config, er
 		Layout:            "simple",
 		DashboardMode:     "default",
 		TimeZone:          "",
-		TimeFormat:        time.UnixDate,
+		TimeFormat:        "",
 		EncodedLogo:       "",
 		HeaderTemplate:    "",
 		FooterTemplate:    "",
@@ -126,6 +192,11 @@ func Load(ctx context.Context, settings backend.AppInstanceSettings) (Config, er
 	// Override provisioned config from env vars, if set
 	if err := envconfig.Process(ctx, &config); err != nil {
 		return Config{}, fmt.Errorf("error in reading config env vars: %w", err)
+	}
+
+	// Validate config
+	if err := config.Validate(); err != nil {
+		return Config{}, fmt.Errorf("error in config settings: %w", err)
 	}
 
 	// Get default HTTP client options

--- a/pkg/plugin/dashboard/time.go
+++ b/pkg/plugin/dashboard/time.go
@@ -20,6 +20,7 @@ type TimeRange struct {
 //     To:  "now-1d/d" -> end of yesterday
 //     When used as boundary, the same string will evaluate to a different time if used in 'From' or 'To'
 //   - absolute unix time: "142321234"
+//   - absolute time string: "2024-12-02T23:00:00.000Z" start from Grafana v11.3.0
 //
 // The required behaviour is clearly documented in the unit tests, time_test.go.
 type now time.Time
@@ -34,6 +35,7 @@ const (
 const (
 	relTimeRegExp      = "^now([+-][0-9]+)([mhdwMy])$"
 	boundaryTimeRegExp = "^(.*?)/([dwMy])$"
+	layout             = "2006-01-02T15:04:05.000Z"
 )
 
 // Convenience function to raise panic with custom message.
@@ -85,8 +87,14 @@ func roundTimeToBoundary(t time.Time, b boundary, boundaryUnit string) time.Time
 
 // Parse time stamp to time.Unix() format.
 func parseAbsTime(s string) time.Time {
+	// Check if time is in unix timestamp format
 	if timeInMs, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return time.Unix(timeInMs/1000, 0)
+	}
+
+	// Check if time is in 2024-12-02T23:00:00.000Z format
+	if absTime, err := time.Parse(layout, s); err == nil && absTime.Unix() > 0 {
+		return absTime
 	}
 
 	panic(unrecognized(s))

--- a/pkg/plugin/dashboard/time.go
+++ b/pkg/plugin/dashboard/time.go
@@ -120,17 +120,17 @@ func NewTimeRange(from, to string) TimeRange {
 }
 
 // Formats Grafana 'From' time spec into absolute printable time.
-func (tr TimeRange) FromFormatted(loc *time.Location) string {
+func (tr TimeRange) FromFormatted(loc *time.Location, layout string) string {
 	n := newNow()
 
-	return n.parseFrom(tr.From).In(loc).Format(time.UnixDate)
+	return n.parseFrom(tr.From).In(loc).Format(layout)
 }
 
 // Formats Grafana 'To' time spec into absolute printable time.
-func (tr TimeRange) ToFormatted(loc *time.Location) string {
+func (tr TimeRange) ToFormatted(loc *time.Location, layout string) string {
 	n := newNow()
 
-	return n.parseTo(tr.To).In(loc).Format(time.UnixDate)
+	return n.parseTo(tr.To).In(loc).Format(layout)
 }
 
 // Make current time custom struct.

--- a/pkg/plugin/report/report.go
+++ b/pkg/plugin/report/report.go
@@ -58,6 +58,16 @@ func (o Options) location(timeZone string) *time.Location {
 	}
 }
 
+// Format of time.
+func (o Options) timeFormat(layout string) string {
+	t := time.Now().Format(layout)
+	if parsedTime, err := time.Parse(layout, t); err != nil || parsedTime.Unix() <= 0 {
+		return time.UnixDate
+	} else {
+		return layout
+	}
+}
+
 // Data structures used inside HTML template.
 type templateData struct {
 	Options
@@ -74,12 +84,12 @@ func (t templateData) IsGridLayout() bool {
 
 // From returns from time string.
 func (t templateData) From() string {
-	return t.TimeRange.FromFormatted(t.location(t.Conf.TimeZone))
+	return t.TimeRange.FromFormatted(t.location(t.Conf.TimeZone), t.timeFormat(t.Conf.TimeFormat))
 }
 
 // To returns to time string.
 func (t templateData) To() string {
-	return t.TimeRange.ToFormatted(t.location(t.Conf.TimeZone))
+	return t.TimeRange.ToFormatted(t.location(t.Conf.TimeZone), t.timeFormat(t.Conf.TimeFormat))
 }
 
 // Logo returns encoded logo.
@@ -340,7 +350,7 @@ func (r *PDF) generateHTMLFile() error {
 	// Template data
 	data := templateData{
 		*r.options,
-		time.Now().Local().In(r.options.location(r.conf.TimeZone)).Format(time.RFC850),
+		time.Now().Local().In(r.options.location(r.conf.TimeZone)).Format(r.options.timeFormat(r.conf.TimeFormat)),
 		r.grafanaDashboard,
 		r.conf,
 	}

--- a/pkg/plugin/report/report.go
+++ b/pkg/plugin/report/report.go
@@ -49,25 +49,6 @@ type Options struct {
 	TimeRange   dashboard.TimeRange
 }
 
-// Location of time zone.
-func (o Options) location(timeZone string) *time.Location {
-	if location, err := time.LoadLocation(timeZone); err != nil {
-		return time.Now().Local().Location()
-	} else {
-		return location
-	}
-}
-
-// Format of time.
-func (o Options) timeFormat(layout string) string {
-	t := time.Now().Format(layout)
-	if parsedTime, err := time.Parse(layout, t); err != nil || parsedTime.Unix() <= 0 {
-		return time.UnixDate
-	} else {
-		return layout
-	}
-}
-
 // Data structures used inside HTML template.
 type templateData struct {
 	Options
@@ -84,12 +65,12 @@ func (t templateData) IsGridLayout() bool {
 
 // From returns from time string.
 func (t templateData) From() string {
-	return t.TimeRange.FromFormatted(t.location(t.Conf.TimeZone), t.timeFormat(t.Conf.TimeFormat))
+	return t.TimeRange.FromFormatted(t.Conf.TimeLocation, t.Conf.TimeFormat)
 }
 
 // To returns to time string.
 func (t templateData) To() string {
-	return t.TimeRange.ToFormatted(t.location(t.Conf.TimeZone), t.timeFormat(t.Conf.TimeFormat))
+	return t.TimeRange.ToFormatted(t.Conf.TimeLocation, t.Conf.TimeFormat)
 }
 
 // Logo returns encoded logo.
@@ -350,7 +331,7 @@ func (r *PDF) generateHTMLFile() error {
 	// Template data
 	data := templateData{
 		*r.options,
-		time.Now().Local().In(r.options.location(r.conf.TimeZone)).Format(r.options.timeFormat(r.conf.TimeFormat)),
+		time.Now().Local().In(r.conf.TimeLocation).Format(r.conf.TimeFormat),
 		r.grafanaDashboard,
 		r.conf,
 	}

--- a/pkg/plugin/report/report.go
+++ b/pkg/plugin/report/report.go
@@ -65,12 +65,12 @@ func (t templateData) IsGridLayout() bool {
 
 // From returns from time string.
 func (t templateData) From() string {
-	return t.TimeRange.FromFormatted(t.Conf.TimeLocation, t.Conf.TimeFormat)
+	return t.TimeRange.FromFormatted(t.Conf.Location, t.Conf.TimeFormat)
 }
 
 // To returns to time string.
 func (t templateData) To() string {
-	return t.TimeRange.ToFormatted(t.Conf.TimeLocation, t.Conf.TimeFormat)
+	return t.TimeRange.ToFormatted(t.Conf.Location, t.Conf.TimeFormat)
 }
 
 // Logo returns encoded logo.
@@ -331,7 +331,7 @@ func (r *PDF) generateHTMLFile() error {
 	// Template data
 	data := templateData{
 		*r.options,
-		time.Now().Local().In(r.conf.TimeLocation).Format(r.conf.TimeFormat),
+		time.Now().Local().In(r.conf.Location).Format(r.conf.TimeFormat),
 		r.grafanaDashboard,
 		r.conf,
 	}

--- a/pkg/plugin/report/report_test.go
+++ b/pkg/plugin/report/report_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/config"
@@ -77,7 +78,7 @@ func TestReport(t *testing.T) {
 			worker.Renderer: worker.New(ctx, 2),
 		}
 
-		rep, err := New(logger, config.Config{}, nil, workerPools, gClient, &Options{
+		rep, err := New(logger, config.Config{TimeFormat: time.UnixDate, Location: time.Now().Location()}, nil, workerPools, gClient, &Options{
 			TimeRange: dashboard.TimeRange{From: "1453206447000", To: "1453213647000"},
 			DashUID:   "testDash",
 		})

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -329,6 +329,10 @@ func (app *App) handleReport(w http.ResponseWriter, req *http.Request) {
 		conf.TimeZone = req.URL.Query().Get("timeZone")
 	}
 
+	if req.URL.Query().Has("timeFormat") {
+		conf.TimeFormat = req.URL.Query().Get("timeFormat")
+	}
+
 	if req.URL.Query().Has("includePanelID") {
 		conf.IncludePanelIDs = makePanelIDs(app.grafanaSemVer, req.URL.Query()["includePanelID"])
 	}

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -339,6 +339,7 @@ func (app *App) handleReport(w http.ResponseWriter, req *http.Request) {
 			if timeZone == "utc" {
 				timeZone = "Etc/UTC"
 			}
+
 			conf.TimeZone = timeZone
 		}
 	}

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -288,42 +288,18 @@ func (app *App) handleReport(w http.ResponseWriter, req *http.Request) {
 
 	if req.URL.Query().Has("theme") {
 		conf.Theme = req.URL.Query().Get("theme")
-		if conf.Theme != "light" && conf.Theme != "dark" {
-			ctxLogger.Debug("invalid theme parameter: " + conf.Theme)
-			http.Error(w, "invalid theme parameter: "+conf.Theme, http.StatusBadRequest)
-
-			return
-		}
 	}
 
 	if req.URL.Query().Has("layout") {
 		conf.Layout = req.URL.Query().Get("layout")
-		if conf.Layout != "simple" && conf.Layout != "grid" {
-			ctxLogger.Debug("invalid layout parameter: " + conf.Layout)
-			http.Error(w, "invalid layout parameter: "+conf.Layout, http.StatusBadRequest)
-
-			return
-		}
 	}
 
 	if req.URL.Query().Has("orientation") {
 		conf.Orientation = req.URL.Query().Get("orientation")
-		if conf.Orientation != "portrait" && conf.Orientation != "landscape" {
-			ctxLogger.Debug("invalid orientation parameter: " + conf.Orientation)
-			http.Error(w, "invalid orientation parameter: "+conf.Orientation, http.StatusBadRequest)
-
-			return
-		}
 	}
 
 	if req.URL.Query().Has("dashboardMode") {
 		conf.DashboardMode = req.URL.Query().Get("dashboardMode")
-		if conf.DashboardMode != "default" && conf.DashboardMode != "full" {
-			ctxLogger.Warn("invalid dashboardMode parameter: " + conf.DashboardMode)
-			http.Error(w, "invalid dashboardMode parameter: "+conf.DashboardMode, http.StatusBadRequest)
-
-			return
-		}
 	}
 
 	if req.URL.Query().Has("timeZone") {
@@ -358,6 +334,14 @@ func (app *App) handleReport(w http.ResponseWriter, req *http.Request) {
 
 	if req.URL.Query().Has("includePanelDataID") {
 		conf.IncludePanelDataIDs = makePanelIDs(app.grafanaSemVer, req.URL.Query()["includePanelDataID"])
+	}
+
+	// Validate config again
+	if err := conf.Validate(); err != nil {
+		ctxLogger.Debug("invalid config: "+conf.String(), "err", err)
+		http.Error(w, "invalid config setting", http.StatusBadRequest)
+
+		return
 	}
 
 	ctxLogger.Info("generate report using config: " + conf.String())

--- a/provisioning/plugins/app.yaml
+++ b/provisioning/plugins/app.yaml
@@ -90,6 +90,12 @@ apps:
       # If empty or an invalid format is provided, the plugin defaults to using local
       # location of the Grafana server.
       #
+      # This config option is only relevant for Grafana < 11.3.0. For instances, using
+      # Grafana 11.3.0 or above, time zone of the current dashboard will be used as
+      # the timezone for the report generation. For deployments with Grafana < v11.3.0, 
+      # the time zone must be configured on grafana-image-renderer (https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#rendering_timezone)
+      # as well to render the panels in that given time zone.
+      #
       # This setting can be overridden for a particular dashboard by using query parameter
       # ?timeZone=America%2FNew_York during report generation process. Note that we 
       # need to escape URL characters

--- a/provisioning/plugins/app.yaml
+++ b/provisioning/plugins/app.yaml
@@ -83,7 +83,7 @@ apps:
       #
       dashboardMode: default
 
-      # Time zone to use the report. This should be provided in IANA format.
+      # Time zone to use in the report. This should be provided in IANA format.
       # More details on IANA format can be obtained from https://www.iana.org/time-zones
       # Eg America/New_York, Asia/Singapore, Australia/Melbourne, Europe/Berlin
       #
@@ -95,6 +95,19 @@ apps:
       # need to escape URL characters
       #
       timeZone: ''
+
+      # Time format to use in the report. The format should be provided as the Golang
+      # time layout. More details can be found in https://pkg.go.dev/time#Layout.
+      #
+      # By default format "Mon Jan _2 15:04:05 MST 2006" is used in the report. If the
+      # provided layout is invalid, it will be ignored and default layout will be used
+      # in the report.
+      #
+      # This setting can be overridden for a particular dashboard by using query parameter
+      # ?timeFormat=2006-01-02+15%3A04%3A05 during report generation process. Note that we 
+      # need to escape URL characters
+      #
+      timeFormat: ''
 
       # Branding logo in the report.
       #

--- a/src/README.md
+++ b/src/README.md
@@ -232,6 +232,14 @@ This config section allows to configure report related settings.
   [IANA format](https://www.iana.org/time-zones). By default, local Grafana server's
   time zone will be used.
 
+> [!NOTE]
+> Starting from Grafana v11.3.0, the dashboard's configured time zone is exposed as a
+query parameter in the dashboard URL and it will be used to set the time zone of the report.
+Hence, for deployments with Grafana v11.3.0 or above, this parameter will not have effect. For
+deployments with Grafana < v11.3.0, the time zone must be configured on
+[grafana-image-renderer](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#rendering_timezone)
+as well to render the panels in that given time zone.
+
 - `file:timeFormat; env:GF_REPORTER_PLUGIN_REPORT_TIMEFORMAT; ui:Time Format`: The time format
   that will be used in the report. It has to conform to the
   [Golang time Layout](https://pkg.go.dev/time#Layout). By default,  format

--- a/src/README.md
+++ b/src/README.md
@@ -232,6 +232,11 @@ This config section allows to configure report related settings.
   [IANA format](https://www.iana.org/time-zones). By default, local Grafana server's
   time zone will be used.
 
+- `file:timeFormat; env:GF_REPORTER_PLUGIN_REPORT_TIMEFORMAT; ui:Time Format`: The time format
+  that will be used in the report. It has to conform to the
+  [Golang time Layout](https://pkg.go.dev/time#Layout). By default,  format
+  "Mon Jan _2 15:04:05 MST 2006" is used.
+
 - `file:logo; env: GF_REPORTER_PLUGIN_REPORT_LOGO; ui:Branding Logo`: This parameter
   takes a base64 encoded image that will be included in the footer of each page in the
   report. Typically, operators can include their organization logos to have "customized"
@@ -311,6 +316,11 @@ to set these values. Currently, the supported query parameters are:
   as value. **Note** that it should be encoded to escape URL specific characters. For example
   to use `America/New_York` query parameter should be
   `<grafanaAppUrl>/api/plugins/mahendrapaipuri-dashboardreporter-app/resources/report?dashUid=<UID of dashboard>&timeZone=America%2FNew_York`
+
+- Query field for dashboard mode is `timeFormat` and it takes a value in [Golang time layout](https://pkg.go.dev/time#Layout)
+  as value. **Note** that it should be encoded to escape URL specific characters. For example
+  to use `Monday, 02-Jan-06 15:04:05 MST` query parameter should be
+  `<grafanaAppUrl>/api/plugins/mahendrapaipuri-dashboardreporter-app/resources/report?dashUid=<UID of dashboard>&timeFormat=Monday%2C+02-Jan-06+15%3A04%3A05+MST`
 
 Besides there are **two** special query parameters available namely:
 

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -30,6 +30,7 @@ export type JsonData = {
   layout?: string;
   dashboardMode?: string;
   timeZone?: string;
+  timeFormat?: string;
   logo?: string;
   headerTemplate?: string;
   footerTemplate?: string;
@@ -67,6 +68,10 @@ type State = {
   timeZone: string;
   // If timeZone has changed
   timeZoneChanged: boolean;
+  // time format in Golang layout
+  timeFormat: string;
+  // If timeFormat has changed
+  timeFormatChanged: boolean;
   // base64 encoded logo
   logo: string;
   // If logo has changed
@@ -121,6 +126,8 @@ export const AppConfig = ({ plugin }: Props) => {
     dashboardModeChanged: false,
     timeZone: jsonData?.timeZone || "",
     timeZoneChanged: false,
+    timeFormat: jsonData?.timeFormat || "",
+    timeFormatChanged: false,
     logo: jsonData?.logo || "",
     logoChanged: false,
     headerTemplate: jsonData?.headerTemplate || "",
@@ -214,6 +221,14 @@ export const AppConfig = ({ plugin }: Props) => {
     });
   };
 
+  const onChangetimeFormat = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({
+      ...state,
+      timeFormat: event.target.value,
+      timeFormatChanged: true,
+    });
+  };
+
   const onChangeLogo = (event: ChangeEvent<HTMLInputElement>) => {
     setState({
       ...state,
@@ -301,6 +316,7 @@ export const AppConfig = ({ plugin }: Props) => {
                     layout: state.layout,
                     dashboardMode: state.dashboardMode,
                     timeZone: state.timeZone,
+                    timeFormat: state.timeFormat,
                     logo: state.logo,
                     headerTemplate: state.headerTemplate,
                     footerTemplate: state.footerTemplate,
@@ -342,6 +358,7 @@ export const AppConfig = ({ plugin }: Props) => {
                     layout: state.layout,
                     dashboardMode: state.dashboardMode,
                     timeZone: state.timeZone,
+                    timeFormat: state.timeFormat,
                     logo: state.logo,
                     headerTemplate: state.headerTemplate,
                     footerTemplate: state.footerTemplate,
@@ -468,6 +485,23 @@ export const AppConfig = ({ plugin }: Props) => {
             label={`Time Zone`}
             value={state.timeZone}
             onChange={onChangetimeZone}
+          />
+        </Field>
+
+        {/* Time format */}
+        <Field
+          label="Time Format"
+          description="Time Format as Golang time Layout (https://pkg.go.dev/time#Layout)."
+          data-testid={testIds.appConfig.tf}
+          className={s.marginTop}
+        >
+          <Input
+            type="string"
+            width={60}
+            id="tz"
+            label={`Time Format`}
+            value={state.timeFormat}
+            onChange={onChangetimeFormat}
           />
         </Field>
 
@@ -637,6 +671,7 @@ export const AppConfig = ({ plugin }: Props) => {
                 layout: state.layout,
                 dashboardMode: state.dashboardMode,
                 timeZone: state.timeZone,
+                timeFormat: state.timeFormat,
                 logo: state.logo,
                 headerTemplate: state.headerTemplate,
                 footerTemplate: state.footerTemplate,
@@ -661,6 +696,7 @@ export const AppConfig = ({ plugin }: Props) => {
               !state.orientationChanged &&
               !state.dashboardModeChanged &&
               !state.timeZoneChanged &&
+              !state.timeFormatChanged &&
               !state.logoChanged &&
               !state.headerTemplateChanged &&
               !state.footerTemplateChanged &&

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -474,7 +474,7 @@ export const AppConfig = ({ plugin }: Props) => {
         {/* Time zone */}
         <Field
           label="Time Zone"
-          description="Time Zone in IANA format. By default time zone of the server will be used."
+          description="Time Zone in IANA format. By default time zone of the server will be used. Only relevant for Grafana < 11.3.0."
           data-testid={testIds.appConfig.tz}
           className={s.marginTop}
         >

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -9,6 +9,7 @@ export const testIds = {
     orientation: "data-testid ac-orientation",
     dashboardMode: "data-testid ac-dashboard-mode",
     tz: "data-testid ac-timezone",
+    tf: "data-testid ac-timeformat",
     logo: "data-testid ac-logo",
     headerTemplate: "data-testid ac-header-template",
     footerTemplate: "data-testid ac-footer-template",


### PR DESCRIPTION
* Time format used in the reports can be configured either from UI, env var or provisioned config. The format must conform to Golang's time layout. Any invalid time format will be ignored and replaced with default UnixDate layout.

Closes #189 
Closes #199 