### PR TITLE
Support rendering panel PNGs natively

### DIFF
--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
       # disable alerting because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false
+      - GF_LIVE_MAX_CONNECTIONS=0
+      - GF_PLUGINS_DISABLE_PLUGINS=grafana-lokiexplore-app
       # Grafana image renderer
       - GF_RENDERING_SERVER_URL=http://renderer_plain:8081/render
       - GF_RENDERING_CALLBACK_URL=http://grafana_plain:${GF_SERVER_HTTP_PORT:-3000}/
@@ -49,6 +51,7 @@ services:
       # Set CI mode to remove header in report
       - __REPORTER_APP_CI_MODE=true
       - GF_REPORTER_PLUGIN_REMOTE_CHROME_URL=${GF_REPORTER_PLUGIN_REMOTE_CHROME_URL:-}
+      - GF_REPORTER_PLUGIN_NATIVE_RENDERER=${GF_REPORTER_PLUGIN_NATIVE_RENDERER:-false}
 
   renderer_plain:
     image: grafana/grafana-image-renderer:latest
@@ -105,6 +108,8 @@ services:
       # disable alerting because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false
+      - GF_LIVE_MAX_CONNECTIONS=0
+      - GF_PLUGINS_DISABLE_PLUGINS=grafana-lokiexplore-app
        # TLS
       - GF_SERVER_PROTOCOL=https
       - GF_SERVER_CERT_KEY=/etc/grafana/tls/localhost.key
@@ -117,6 +122,7 @@ services:
       # Set CI mode to remove header in report
       - __REPORTER_APP_CI_MODE=true
       - GF_REPORTER_PLUGIN_REMOTE_CHROME_URL=${GF_REPORTER_PLUGIN_REMOTE_CHROME_URL:-}
+      - GF_REPORTER_PLUGIN_NATIVE_RENDERER=${GF_REPORTER_PLUGIN_NATIVE_RENDERER:-false}
       - GF_REPORTER_PLUGIN_SKIP_TLS_CHECK=true
 
   renderer_tls:

--- a/.github/workflows/step_e2e-tests.yml
+++ b/.github/workflows/step_e2e-tests.yml
@@ -18,6 +18,7 @@ jobs:
           - grafana-version: 10.3.0
             remote-chrome-url: ''
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            native-rendering: false
             # snapshots-folder: local-chrome
             name: local-chrome-10.3.0-with-features
 
@@ -25,6 +26,7 @@ jobs:
           - grafana-version: 10.4.5
             remote-chrome-url: ''
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            native-rendering: true
             # snapshots-folder: local-chrome
             name: local-chrome-10.4.5-with-features
 
@@ -33,6 +35,7 @@ jobs:
           - grafana-version: 10.4.7
             remote-chrome-url: ws://localhost:9222
             feature-flags: 'externalServiceAccounts'
+            native-rendering: false
             # snapshots-folder: remote-chrome
             name: remote-chrome-10.4.7-without-features
 
@@ -40,15 +43,25 @@ jobs:
           - grafana-version: 11.1.0
             remote-chrome-url: ws://localhost:9222
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            native-rendering: false
             # snapshots-folder: remote-chrome
             name: remote-chrome-11.1.0-with-features
 
-          # Latest Grafana with local chrome
-          - grafana-version: 11.3.0
+          # Latest Grafana with local chrome and grafana-image-renderer
+          - grafana-version: 11.4.0
             remote-chrome-url: ws://localhost:9222
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            native-rendering: false
             # snapshots-folder: remote-chrome
-            name: local-chrome-11.3.0-with-features
+            name: local-chrome-11.4.0-with-features
+
+          # Latest Grafana with local chrome and native-renderer
+          - grafana-version: 11.4.0
+            remote-chrome-url: ws://localhost:9222
+            feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            native-rendering: true
+            # snapshots-folder: remote-chrome
+            name: local-chrome-11.4.0-with-features-native-renderer
 
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +89,7 @@ jobs:
         env:
           GRAFANA_VERSION: ${{ matrix.grafana-version }}
           GF_REPORTER_PLUGIN_REMOTE_CHROME_URL: ${{ matrix.remote-chrome-url }}
+          GF_REPORTER_PLUGIN_NATIVE_RENDERER: ${{ matrix.native-rendering }}
           GF_FEATURE_TOGGLES_ENABLE: ${{ matrix.feature-flags }}
         run: |
           # Upload/Download artifacts wont preserve permissions

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,20 +40,24 @@ services:
       # the token from a service account to read dashboards
       - GF_FEATURE_TOGGLES_ENABLE=${GF_FEATURE_TOGGLES_ENABLE:-accessControlOnCall,idForwarding,externalServiceAccounts}
       - GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED=${GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED:-true}
-      # disable alerting because it vomits logs
+      # disable alerting and Grafana live because it vomits logs
       - GF_ALERTING_ENABLED=false
       - GF_UNIFIED_ALERTING_ENABLED=false
+      - GF_LIVE_MAX_CONNECTIONS=0
+      - GF_PLUGINS_DISABLE_PLUGINS=grafana-lokiexplore-app
       # Grafana image renderer
       - GF_RENDERING_SERVER_URL=http://renderer:8081/render
       - GF_RENDERING_CALLBACK_URL=http://grafana:${GF_SERVER_HTTP_PORT:-3000}/
       - "GF_LOG_FILTERS=rendering:debug plugin.mahendrapaipuri-dashboardreporter-app:debug"
+      # Current plugin config
+      - GF_REPORTER_PLUGIN_NATIVE_RENDERER=${GF_REPORTER_PLUGIN_NATIVE_RENDERER:-false}
   renderer:
     image: grafana/grafana-image-renderer:latest
     environment:
       # Recommendation of grafana-image-renderer for optimal performance
       # https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#configuration
       - RENDERING_MODE=clustered
-      - RENDERING_CLUSTERING_MODE=browser
+      - RENDERING_CLUSTERING_MODE=context
       - RENDERING_CLUSTERING_MAX_CONCURRENCY=5
       - RENDERING_CLUSTERING_TIMEOUT=60
       - IGNORE_HTTPS_ERRORS=true

--- a/pkg/plugin/chrome/local.go
+++ b/pkg/plugin/chrome/local.go
@@ -141,10 +141,4 @@ func (i *LocalInstance) Close(logger log.Logger) {
 			logger.Error("got error from cancel browser context", "error", err)
 		}
 	}
-
-	if i.allocCtx != nil {
-		if err := chromedp.Cancel(i.allocCtx); err != nil {
-			logger.Error("got error from cancel browser allocator context", "error", err)
-		}
-	}
 }

--- a/pkg/plugin/chrome/tab.go
+++ b/pkg/plugin/chrome/tab.go
@@ -102,6 +102,11 @@ func (t *Tab) Context() context.Context {
 	return t.ctx
 }
 
+// Target returns tab's target ID.
+func (t *Tab) Target() *chromedp.Target {
+	return chromedp.FromContext(t.Context()).Target
+}
+
 // PrintToPDF returns chroms tasks that print the requested HTML into a PDF and returns the PDF stream handle.
 func (t *Tab) PrintToPDF(options PDFOptions, writer io.Writer) error {
 	err := chromedp.Run(t.ctx, chromedp.Tasks{

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -41,6 +41,7 @@ type Config struct {
 	MaxBrowserWorkers   int    `env:"GF_REPORTER_PLUGIN_MAX_BROWSER_WORKERS, overwrite"    json:"maxBrowserWorkers"`
 	MaxRenderWorkers    int    `env:"GF_REPORTER_PLUGIN_MAX_RENDER_WORKERS, overwrite"     json:"maxRenderWorkers"`
 	RemoteChromeURL     string `env:"GF_REPORTER_PLUGIN_REMOTE_CHROME_URL, overwrite"      json:"remoteChromeUrl"`
+	NativeRendering     bool   `env:"GF_REPORTER_PLUGIN_NATIVE_RENDERER, overwrite"        json:"nativeRenderer"`
 	IncludePanelIDs     []string
 	ExcludePanelIDs     []string
 	IncludePanelDataIDs []string
@@ -141,10 +142,12 @@ func (c *Config) String() string {
 		"Theme: %s; Orientation: %s; Layout: %s; Dashboard Mode: %s; "+
 			"Time Zone: %s; Time Format: %s; Encoded Logo: %s; "+
 			"Max Renderer Workers: %d; Max Browser Workers: %d; Remote Chrome Addr: %s; App URL: %s; "+
-			"TLS Skip verify: %v; Included Panel IDs: %s; Excluded Panel IDs: %s Included Data for Panel IDs: %s",
+			"TLS Skip verify: %v; Included Panel IDs: %s; Excluded Panel IDs: %s Included Data for Panel IDs: %s; "+
+			"Native Renderer: %v; Client Timeout: %d",
 		c.Theme, c.Orientation, c.Layout, c.DashboardMode, c.TimeZone, c.TimeFormat,
 		encodedLogo, c.MaxRenderWorkers, c.MaxBrowserWorkers, c.RemoteChromeURL, appURL,
-		c.SkipTLSCheck, includedPanelIDs, excludedPanelIDs, includeDataPanelIDs,
+		c.SkipTLSCheck, includedPanelIDs, excludedPanelIDs, includeDataPanelIDs, c.NativeRendering,
+		int(c.HTTPClientOptions.Timeouts.Timeout.Seconds()),
 	)
 }
 

--- a/pkg/plugin/dashboard/data.go
+++ b/pkg/plugin/dashboard/data.go
@@ -3,16 +3,18 @@ package dashboard
 import (
 	"context"
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"maps"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/browser"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/chrome"
+	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/helpers"
 )
 
 // PanelCSV returns CSV data of a given panel.
@@ -20,11 +22,13 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 	// Get panel CSV data URL
 	panelURL := d.panelCSVURL(p)
 
+	defer helpers.TimeTrack(time.Now(), "fetch panel CSV data", d.logger, "fetcher", "native", "panel_id", p.ID, "url", panelURL.String())
+
 	// Create a new tab
 	tab := d.chromeInstance.NewTab(d.logger, d.conf)
 	// Set a timeout for the tab
 	// Fail-safe for newer Grafana versions, if css has been changed.
-	tab.WithTimeout(d.conf.HTTPClientOptions.Timeouts.Timeout)
+	tab.WithTimeout(2 * d.conf.HTTPClientOptions.Timeouts.Timeout)
 	defer tab.Close(d.logger)
 
 	headers := make(map[string]any)
@@ -35,9 +39,7 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 		}
 	}
 
-	d.logger.Debug("fetch table data via browser", "url", panelURL)
-
-	err := tab.NavigateAndWaitFor(panelURL, headers, "networkIdle")
+	err := tab.NavigateAndWaitFor(panelURL.String(), headers, "networkIdle")
 	if err != nil {
 		return nil, fmt.Errorf("NavigateAndWaitFor: %w", err)
 	}
@@ -51,11 +53,16 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 	// Listen for download events. Downloading from JavaScript won't emit any network events.
 	chromedp.ListenTarget(tab.Context(), func(event interface{}) {
 		if eventDownloadWillBegin, ok := event.(*browser.EventDownloadWillBegin); ok {
-			d.logger.Debug("got CSV download URL", "url", eventDownloadWillBegin.URL)
+			d.logger.Debug("got CSV download URL", "panel_id", p.ID, "url", eventDownloadWillBegin.URL)
 			// once we have the download URL, we can fetch the CSV data via JavaScript.
 			blobURLCh <- eventDownloadWillBegin.URL
 		}
 	})
+
+	js := fmt.Sprintf(
+		`waitForCSVData(version = '%s', timeout = %d);`,
+		d.appVersion, d.conf.HTTPClientOptions.Timeouts.Timeout.Milliseconds(),
+	)
 
 	downTasks := chromedp.Tasks{
 		// Downloads needs to be allowed, otherwise the CSV request will be denied.
@@ -63,34 +70,17 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 		browser.SetDownloadBehavior(browser.SetDownloadBehaviorBehaviorAllowAndName).
 			WithDownloadPath("/dev/null").
 			WithEventsEnabled(true),
-	}
-
-	if err = tab.RunWithTimeout(2*time.Second, downTasks); err != nil {
-		return nil, fmt.Errorf("error setting download behavior: %w", err)
-	}
-
-	if err = tab.RunWithTimeout(2*time.Second, chromedp.WaitVisible(selDownloadCSVButton, chromedp.ByQuery)); err != nil {
-		return nil, fmt.Errorf("error waiting for download CSV button: %w", err)
-	}
-
-	if err = tab.RunWithTimeout(2*time.Second, chromedp.Click(selInspectPanelDataTabExpandDataOptions, chromedp.ByQuery)); err != nil {
-		return nil, fmt.Errorf("error clicking on expand data options: %w", err)
-	}
-
-	if err = tab.RunWithTimeout(1*time.Second, chromedp.Click(selInspectPanelDataTabApplyTransformationsToggle, chromedp.ByQuery)); err != nil && !errors.Is(err, context.DeadlineExceeded) {
-		return nil, fmt.Errorf("error clicking on apply transformations toggle: %w", err)
-	}
-
-	if err = tab.RunWithTimeout(1*time.Second, chromedp.Click(selInspectPanelDataTabApplyTransformationsToggle, chromedp.ByQuery)); err != nil && !errors.Is(err, context.DeadlineExceeded) {
-		return nil, fmt.Errorf("error clicking on apply transformations toggle: %w", err)
+		chromedp.Evaluate(d.jsContent, nil),
+		chromedp.Evaluate(js, nil, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}),
 	}
 
 	// Run all tasks in a goroutine.
 	// If an error occurs, it will be sent to the errCh channel.
 	// If a element can't be found, a timeout will occur and the context will be canceled.
 	go func() {
-		task := chromedp.Evaluate(clickDownloadCSVButton, nil)
-		if err := tab.Run(task); err != nil {
+		if err := tab.Run(downTasks); err != nil {
 			errCh <- fmt.Errorf("error fetching CSV URL from browser %s: %w", panelURL, err)
 		}
 	}()
@@ -120,7 +110,7 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 		chrome.WithAwaitPromise,
 	)
 
-	if err := tab.RunWithTimeout(45*time.Second, task); err != nil {
+	if err := tab.RunWithTimeout(d.conf.HTTPClientOptions.Timeouts.Timeout, task); err != nil {
 		return nil, fmt.Errorf("error fetching CSV data from URL from browser %s: %w", panelURL, err)
 	}
 
@@ -144,13 +134,18 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 }
 
 // panelCSVURL returns URL to fetch panel's CSV data.
-func (d *Dashboard) panelCSVURL(p Panel) string {
+func (d *Dashboard) panelCSVURL(p Panel) *url.URL {
 	values := maps.Clone(d.model.Dashboard.Variables)
 	values.Add("theme", d.conf.Theme)
 	values.Add("viewPanel", p.ID)
 	values.Add("inspect", p.ID)
 	values.Add("inspectTab", "data")
 
+	// Make a copy of appURL
+	panelURL := *d.appURL
+	panelURL.Path = fmt.Sprintf("/d/%s/_", d.model.Dashboard.UID)
+	panelURL.RawQuery = values.Encode()
+
 	// Get Panel API endpoint
-	return fmt.Sprintf("%s/d/%s/_?%s", d.appURL, d.model.Dashboard.UID, values.Encode())
+	return &panelURL
 }

--- a/pkg/plugin/dashboard/js/panels.js
+++ b/pkg/plugin/dashboard/js/panels.js
@@ -1,0 +1,142 @@
+// Javascript to expand row panels and wait until queries
+// and panels are fully loaded on the current Grafana
+// dashboard
+
+// Base backoff duration in ms
+const baseDelayMsecs = 10;
+
+// Define a timer to wait until next try
+const timer = ms => new Promise(res => setTimeout(res, ms));
+
+// Panel data
+const panelData = selector => [...document.querySelectorAll('[' + selector + ']')].map((e) => ({ "x": e.getBoundingClientRect().x, "y": e.getBoundingClientRect().y, "width": e.getBoundingClientRect().width, "height": e.getBoundingClientRect().height, "title": e.innerText.split('\n')[0], "id": e.getAttribute(selector) }))
+
+/**
+ * Semantic Versioning Comparing
+ * #see https://semver.org/
+ * #see https://stackoverflow.com/a/65687141/456536
+ * #see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#options
+ */
+function semverCompare(a, b) {
+    if (a.startsWith(b + "-")) return -1
+    if (b.startsWith(a + "-")) return 1
+    return a.localeCompare(b, undefined, { numeric: true, sensitivity: "case", caseFirst: "upper" })
+}
+
+// Wait for queries to finish and panels to load data
+const waitForQueriesAndVisualizations = async (version = '11.3.0', mode = 'default', timeout = 30000) => {
+    // Remove v prefix from version
+    const ver = version.split('v')[1];
+
+    // Set selector based on version
+    let selector;
+    if (semverCompare(ver, '11.3.0') === -1) {
+        selector = 'data-panelid';
+    } else {
+        selector = 'data-viz-panel-key'
+    }
+
+    // Expand row panels if mode is full
+    if (mode === 'full') {
+        // For Grafana <= v10
+        [...document.getElementsByClassName('dashboard-row--collapsed')].map((e) => e.getElementsByClassName('dashboard-row__title pointer')[0].click());
+        // For Grafana > v10 and <= v11
+        [...document.querySelectorAll("[data-testid='dashboard-row-container']")].map((e) => [...e.querySelectorAll("[aria-expanded=false]")].map((e) => e.click()));
+        // For Grafana >= v11.3
+        [...document.querySelectorAll("[aria-label='Expand row']")].map((e) => e.click());
+    }
+
+    // Always scroll to bottom of the page
+    window.scrollTo(0, document.body.scrollHeight);
+
+    // Panel count should be unchanged for minStableSizeIterations times
+    let countStableSizeIterations = 0;
+    const minStableSizeIterations = 3;
+
+    // Initialise parameters
+    let lastPanels = [];
+    let checkCounts = 1;
+    const start = Date.now();
+
+    while (Date.now() - start < timeout) {
+        // Get current number of rendered panels
+        let currentPanels = document.querySelectorAll("[class$='panel-content']");
+
+        // If current panels and last panels are same, increment iterator
+        if (lastPanels.length !== 0 && currentPanels.length === lastPanels.length) {
+            countStableSizeIterations++;
+        } else {
+            countStableSizeIterations = 0; // reset the counter
+        }
+
+        // If panel count is stable for minStableSizeIterations, return. We assume that
+        // the dashboard has loaded with all panels
+        if (countStableSizeIterations >= minStableSizeIterations) {
+            return panelData(selector);
+        }
+
+        // If not, wait and retry
+        lastPanels = currentPanels;
+        await timer(baseDelayMsecs * 2 ** checkCounts);
+        checkCounts++;
+    }
+
+    return panelData(selector);
+};
+
+// Wait for CSV download button to appear
+const waitForCSVDownloadButton = async () => {
+    // Initialise parameters
+    let checkCounts = 1;
+    const start = Date.now();
+
+    // Wait for download button
+    while (Date.now() - start < 1000) {
+        // Get all buttons on inspect panel
+        let buttons = document.querySelectorAll('div[aria-label="Panel inspector Data content"] button[type="button"]');
+
+        // Ensure download CSV button exists in buttons
+        for (let i = 0; i < buttons.length; i++) {
+            if (buttons[i].innerText === 'Download CSV') {
+                buttons[i].click();
+                return;
+            }
+        }
+
+        // If not, wait and retry
+        await timer(baseDelayMsecs * 2 ** checkCounts);
+        checkCounts++;
+    }
+
+    return;
+};
+
+// Ensures format data toggle is checked to apply all transformations
+const checkFormatDataToggle = async () => {
+    // Get all toggles on inspect panel
+    let toggles = document.querySelectorAll('div[data-testid="dataOptions"] input#formatted-data-toggle');
+
+    // Ensure format data toggle is checked
+    for (let i = 0; i < toggles.length; i++) {
+        if (!toggles[i].checked) {
+            toggles[i].click();
+            return;
+        }
+    }
+
+    return;
+};
+
+// Waits for CSV data to be ready to download
+const waitForCSVData = async (version = '11.3.0', timeout = 30000) => {
+    // First wait for panel to load data
+    await waitForQueriesAndVisualizations(version, 'default', timeout);
+
+    // Ensure format data toggle is checked
+    await checkFormatDataToggle();
+
+    // Wait for CSV download button and click it
+    await waitForCSVDownloadButton();
+
+    return;
+};

--- a/pkg/plugin/dashboard/panels_test.go
+++ b/pkg/plugin/dashboard/panels_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/chrome"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/config"
-	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/worker"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -97,17 +96,11 @@ func TestDashboardFetchWithLocalChrome(t *testing.T) {
 				HTTPClientOptions: httpclient.Options{Timeouts: &httpclient.DefaultTimeoutOptions},
 			}
 
-			ctx := context.Background()
-			workerPools := worker.Pools{
-				worker.Browser:  worker.New(ctx, 6),
-				worker.Renderer: worker.New(ctx, 2),
-			}
-			dash := New(
+			dash, err := New(
 				log.NewNullLogger(),
 				&conf,
 				http.DefaultClient,
 				chromeInstance,
-				workerPools,
 				ts.URL,
 				"v11.4.0",
 				&Model{Dashboard: struct {
@@ -125,7 +118,12 @@ func TestDashboardFetchWithLocalChrome(t *testing.T) {
 					backend.CookiesHeaderName: []string{"cookie"},
 				},
 			)
-			d, err := dash.panelData(context.Background())
+
+			Convey("New dashboard should receive no errors", func() {
+				So(err, ShouldBeNil)
+			})
+
+			d, err := dash.panelMetaData(context.Background())
 
 			Convey("It should receive no errors", func() {
 				So(err, ShouldBeNil)
@@ -200,17 +198,11 @@ func TestDashboardFetchWithRemoteChrome(t *testing.T) {
 				HTTPClientOptions: httpclient.Options{Timeouts: &httpclient.DefaultTimeoutOptions},
 			}
 
-			ctx := context.Background()
-			workerPools := worker.Pools{
-				worker.Browser:  worker.New(ctx, 6),
-				worker.Renderer: worker.New(ctx, 2),
-			}
-			dash := New(
+			dash, err := New(
 				log.NewNullLogger(),
 				&conf,
 				http.DefaultClient,
 				chromeInstance,
-				workerPools,
 				ts.URL,
 				"v11.4.0",
 				&Model{Dashboard: struct {
@@ -228,7 +220,12 @@ func TestDashboardFetchWithRemoteChrome(t *testing.T) {
 					backend.CookiesHeaderName: []string{"cookie"},
 				},
 			)
-			d, err := dash.panelData(context.Background())
+
+			Convey("New dashboard should receive no errors", func() {
+				So(err, ShouldBeNil)
+			})
+
+			d, err := dash.panelMetaData(context.Background())
 
 			Convey("It should receive no errors", func() {
 				So(err, ShouldBeNil)
@@ -248,12 +245,11 @@ func TestDashboardFetchWithRemoteChrome(t *testing.T) {
 
 func TestDashboardCreatePanels(t *testing.T) {
 	Convey("When creating panels for Dashboard", t, func() {
-		dash := New(
+		dash, err := New(
 			log.NewNullLogger(),
 			nil,
 			nil,
 			nil,
-			worker.Pools{},
 			"http://localhost:3000",
 			"v11.4.0",
 			&Model{Dashboard: struct {
@@ -270,10 +266,14 @@ func TestDashboardCreatePanels(t *testing.T) {
 			nil,
 		)
 
+		Convey("New dashboard should receive no errors", func() {
+			So(err, ShouldBeNil)
+		})
+
 		dashDataString := `[{"width":940,"height":258,"x":0,"y":0,"id":"12"},{"width":940,"height":258,"x":940,"y":0,"id":"26"},{"width":940,"height":258,"x":0,"y":0,"id":"27"}]`
 
 		var dashData []interface{}
-		err := json.Unmarshal([]byte(dashDataString), &dashData)
+		err = json.Unmarshal([]byte(dashDataString), &dashData)
 
 		Convey("setup dashboard data unmarshal", func() {
 			So(err, ShouldBeNil)

--- a/pkg/plugin/dashboard/renderer.go
+++ b/pkg/plugin/dashboard/renderer.go
@@ -8,19 +8,96 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/helpers"
 )
 
 var getPanelRetrySleepTime = time.Duration(10) * time.Second
 
 // PanelPNG returns encoded PNG image of a given panel.
 func (d *Dashboard) PanelPNG(ctx context.Context, p Panel) (PanelImage, error) {
+	if d.conf.NativeRendering {
+		return d.panelPNGNativeRenderer(ctx, p)
+	}
+
+	return d.panelPNGImageRenderer(ctx, p)
+}
+
+// panelPNGNativeRenderer returns panel PNG data by capturing screenshot of panel in browser.
+func (d *Dashboard) panelPNGNativeRenderer(_ context.Context, p Panel) (PanelImage, error) {
+	// Get panel URL
+	panelURL := d.panelPNGURL(p, false)
+
+	defer helpers.TimeTrack(time.Now(), "fetch panel PNG", d.logger, "panel_id", p.ID, "renderer", "native", "url", panelURL.String())
+
+	// Create a new tab
+	tab := d.chromeInstance.NewTab(d.logger, d.conf)
+	tab.WithTimeout(2 * d.conf.HTTPClientOptions.Timeouts.Timeout)
+	defer tab.Close(d.logger)
+
+	headers := make(map[string]any)
+
+	for name, values := range d.authHeader {
+		for _, value := range values {
+			headers[name] = value
+		}
+	}
+
+	err := tab.NavigateAndWaitFor(panelURL.String(), headers, "networkIdle")
+	if err != nil {
+		return PanelImage{}, fmt.Errorf("NavigateAndWaitFor: %w", err)
+	}
+
+	var buf []byte
+
+	tasks := make(chromedp.Tasks, 0)
+
+	js := fmt.Sprintf(
+		`waitForQueriesAndVisualizations(version = '%s', timeout = %d);`,
+		d.appVersion, d.conf.HTTPClientOptions.Timeouts.Timeout.Milliseconds(),
+	)
+
+	tasks = append(tasks, chromedp.Tasks{
+		chromedp.Evaluate(d.jsContent, nil),
+		chromedp.EmulateViewport(d.panelDims(p)),
+		chromedp.Evaluate(js, nil, func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}),
+		chromedp.CaptureScreenshot(&buf),
+	}...)
+
+	if err := tab.Run(tasks); err != nil {
+		return PanelImage{}, fmt.Errorf("error fetching panel PNG from browser %s: %w", panelURL.String(), err)
+	}
+
+	sb := &bytes.Buffer{}
+
+	encoder := base64.NewEncoder(base64.StdEncoding, sb)
+
+	if _, err = encoder.Write(buf); err != nil {
+		return PanelImage{}, fmt.Errorf("error reading data of panel PNG: %w", err)
+	}
+
+	return PanelImage{
+		Image:    sb.String(),
+		MimeType: "image/png",
+	}, nil
+}
+
+// panelPNGImageRenderer returns panel PNG data by making API requests to grafana-image-renderer.
+func (d *Dashboard) panelPNGImageRenderer(ctx context.Context, p Panel) (PanelImage, error) {
 	// Get panel render URL
-	panelURL := d.panelPNGURL(p, d.model.Dashboard.UID)
+	panelURL := d.panelPNGURL(p, true)
+
+	defer helpers.TimeTrack(time.Now(), "fetch panel PNG", d.logger, "panel_id", p.ID, "renderer", "grafana-image-renderer", "url", panelURL.String())
 
 	// Create a new request for panel
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, panelURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, panelURL.String(), nil)
 	if err != nil {
 		return PanelImage{}, fmt.Errorf("error creating request for %s: %w", panelURL, err)
 	}
@@ -83,33 +160,52 @@ func (d *Dashboard) PanelPNG(ctx context.Context, p Panel) (PanelImage, error) {
 	}, nil
 }
 
-// panelPNGURL returns the URL to fetch panel PNd.
-func (d *Dashboard) panelPNGURL(p Panel, dashUID string) string {
+// panelPNGURL returns the URL to fetch panel PNG.
+func (d *Dashboard) panelPNGURL(p Panel, render bool) *url.URL {
 	values := maps.Clone(d.model.Dashboard.Variables)
 	values.Add("theme", d.conf.Theme)
 	values.Add("panelId", p.ID)
 
-	if d.conf.TimeZone != "" {
+	if d.conf.TimeZone != "" && values.Get("timezone") == "" {
 		values.Add("timezone", d.conf.TimeZone)
 	}
 
+	// Get panel dimensions
+	w, h := d.panelDims(p)
+	values.Add("width", strconv.FormatInt(w, 10))
+	values.Add("height", strconv.FormatInt(h, 10))
+
+	// If render is true call grafana-image-renderer API URL
+	var renderer string
+	if render {
+		renderer = "render/"
+	}
+
+	// Make a copy of appURL
+	panelURL := *d.appURL
+	panelURL.Path = fmt.Sprintf("/%sd-solo/%s/_", renderer, d.model.Dashboard.UID)
+	panelURL.RawQuery = values.Encode()
+
+	// Get Panel API endpoint
+	return &panelURL
+}
+
+// panelDims returns width and height of panel based on layout.
+func (d *Dashboard) panelDims(p Panel) (int64, int64) {
 	// If using a grid layout we use 100px for width and 36px for height scalind.
 	// Grafana panels are fitted into 24 units width and height units are said to
 	// 30px in docs but 36px seems to be better.
 	//
 	// In simple layout we create panels with 1000x500 resolution always and include
 	// them one in each page of report
+	var width, height int64
 	if d.conf.Layout == "grid" {
-		width := int(p.GridPos.W * 100)
-		height := int(p.GridPos.H * 36)
-
-		values.Add("width", strconv.Itoa(width))
-		values.Add("height", strconv.Itoa(height))
+		width = int64(p.GridPos.W * 100)
+		height = int64(p.GridPos.H * 36)
 	} else {
-		values.Add("width", "1000")
-		values.Add("height", "500")
+		width = 1000
+		height = 500
 	}
 
-	// Get Panel API endpoint
-	return fmt.Sprintf("%s/render/d-solo/%s/_?%s", d.appURL, dashUID, values.Encode())
+	return width, height
 }

--- a/pkg/plugin/dashboard/renderer_test.go
+++ b/pkg/plugin/dashboard/renderer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/chrome"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/config"
-	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/worker"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -42,18 +41,11 @@ func TestFetchPanelPNG(t *testing.T) {
 		variables.Add("from", "now-1h")
 		variables.Add("to", "now")
 
-		ctx := context.Background()
-		workerPools := worker.Pools{
-			worker.Browser:  worker.New(ctx, 6),
-			worker.Renderer: worker.New(ctx, 2),
-		}
-
-		dash := New(
+		dash, err := New(
 			log.NewNullLogger(),
 			&conf,
 			http.DefaultClient,
 			&chrome.LocalInstance{},
-			workerPools,
 			ts.URL,
 			"v11.1.0",
 			&Model{Dashboard: struct {
@@ -72,7 +64,12 @@ func TestFetchPanelPNG(t *testing.T) {
 				backend.OAuthIdentityTokenHeaderName: []string{"Bearer token"},
 			},
 		)
-		_, err := dash.PanelPNG(context.Background(), Panel{ID: "44", Type: "singlestat", Title: "title", GridPos: GridPos{}})
+
+		Convey("New dashboard should receive no errors", func() {
+			So(err, ShouldBeNil)
+		})
+
+		_, err = dash.PanelPNG(context.Background(), Panel{ID: "44", Type: "singlestat", Title: "title", GridPos: GridPos{}})
 
 		Convey("It should receives no errors", func() {
 			So(err, ShouldBeNil)
@@ -108,12 +105,11 @@ func TestFetchPanelPNG(t *testing.T) {
 		// Use grid layout
 		conf.Layout = "grid"
 
-		dash = New(
+		dash, err = New(
 			log.NewNullLogger(),
 			&conf,
 			http.DefaultClient,
 			&chrome.LocalInstance{},
-			workerPools,
 			ts.URL,
 			"v11.1.0",
 			&Model{Dashboard: struct {
@@ -132,6 +128,10 @@ func TestFetchPanelPNG(t *testing.T) {
 				backend.OAuthIdentityTokenHeaderName: []string{"token"},
 			},
 		)
+
+		Convey("New dashboard should receive no errors using grid layout", func() {
+			So(err, ShouldBeNil)
+		})
 
 		_, err = dash.PanelPNG(context.Background(), Panel{ID: "44", Type: "graph", Title: "title", GridPos: GridPos{H: 6, W: 24}})
 

--- a/pkg/plugin/dashboard/types.go
+++ b/pkg/plugin/dashboard/types.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/chrome"
 	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/config"
-	"github.com/mahendrapaipuri/grafana-dashboard-reporter-app/pkg/plugin/worker"
 )
 
 // Dashboard represents a Grafana dashboard resource.
@@ -19,9 +18,9 @@ type Dashboard struct {
 	conf           *config.Config
 	httpClient     *http.Client
 	chromeInstance chrome.Instance
-	workerPools    worker.Pools
-	appURL         string
+	appURL         *url.URL
 	appVersion     string
+	jsContent      string
 	model          *Model
 	authHeader     http.Header
 }

--- a/pkg/plugin/helpers/helpers.go
+++ b/pkg/plugin/helpers/helpers.go
@@ -1,0 +1,14 @@
+package helpers
+
+import (
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+// TimeTrack tracks execution time of each function.
+func TimeTrack(start time.Time, name string, logger log.Logger, args ...interface{}) {
+	elapsed := time.Since(start)
+	args = append(args, "duration", elapsed.String())
+	logger.Debug(name, args...)
+}

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -335,17 +335,22 @@ func (app *App) handleReport(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	grafanaDashboard := dashboard.New(
+	grafanaDashboard, err := dashboard.New(
 		ctxLogger,
 		&conf,
 		app.httpClient,
 		app.chromeInstance,
-		app.workerPools,
 		grafanaAppURL,
 		app.grafanaSemVer,
 		model,
 		authHeader,
 	)
+	if err != nil {
+		ctxLogger.Error("failed to create a new dashboard", "err", err)
+		http.Error(w, "error generating report", http.StatusInternalServerError)
+
+		return
+	}
 
 	ctxLogger.Info(fmt.Sprintf("generate report using %s chrome", app.chromeInstance.Name()))
 

--- a/pkg/plugin/worker/pool.go
+++ b/pkg/plugin/worker/pool.go
@@ -19,12 +19,12 @@ const (
 )
 
 func New(ctx context.Context, maxWorker int) *Pool {
-	queue := make(chan func(), maxWorker)
-	ctx, cancel := context.WithCancel(ctx)
-
 	if maxWorker <= 0 {
 		maxWorker = runtime.NumCPU()
 	}
+
+	queue := make(chan func(), maxWorker)
+	ctx, cancel := context.WithCancel(ctx)
 
 	for range maxWorker {
 		go func() {

--- a/provisioning/plugins/app.yaml
+++ b/provisioning/plugins/app.yaml
@@ -162,3 +162,13 @@ apps:
       # chrome instance
       #
       remoteChromeUrl: ''
+
+      # Render Panel PNGs natively using current plugin.
+      # When set to `true`, the plugin generates panel PNGs natively without using
+      # `grafana-image-renderer`. Thus, if it is set to `true`, there is no need
+      # to install `grafana-image-renderer`. However, `chromium` must be available
+      # for report and panel PNG generation
+      #
+      # THIS IS HIGHLY EXPERIMENTAL FEATURE.
+      #
+      nativeRenderer: false

--- a/src/README.md
+++ b/src/README.md
@@ -47,10 +47,10 @@ generating and sending reports automatically, they should look into official plu
 
 However, it is still possible to install this plugin using `grafana-cli` by overriding
 `pluginUrl` by using URL from [releases](https://github.com/mahendrapaipuri/grafana-dashboard-reporter-app/releases).
-For example following command will install plugin version `v1.6.3`
+For example following command will install plugin version `1.7.1`
 
 ```bash
-grafana-cli --pluginUrl https://github.com/mahendrapaipuri/grafana-dashboard-reporter-app/releases/download/v1.6.3/mahendrapaipuri-dashboardreporter-app-1.6.3.zip plugins install mahendrapaipuri-dashboardreporter-app
+VERSION=1.7.1 grafana-cli --pluginUrl "https://github.com/mahendrapaipuri/grafana-dashboard-reporter-app/releases/download/v${VERSION}/mahendrapaipuri-dashboardreporter-app-${VERSION}.zip" plugins install mahendrapaipuri-dashboardreporter-app
 ```
 
 Similarly, `nightly` version can be installed suing
@@ -589,6 +589,23 @@ error messages will be as follows:
 - If `chromium` fails to run, it suggests that there are missing dependent libraries on
 the host. In that case, we advise to install `chromium` on the machine which will
 install all the dependent libraries.
+
+- On Ubuntu, for a more hassle-free experience, install `google-chrome`
+from [DEB package](https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb)
+instead of installing `chromium` from `snap`.
+
+- If Grafana server is running inside a systemd service file, sometimes users might
+see errors as follows:
+
+  ```bash
+  couldn't create browser context: chrome failed to start:\nchrome_crashpad_handler: --database is required\nTry 'chrome_crashpad_handler --help' for more information.\n[147301:147301:0102/092026.518581:ERROR:socket.cc(120)] recvmsg: Connection reset by peer (104)\n"
+  ```
+
+  This is due to `google-chrome`/`chromium` not able to create user profile
+  directories. A solution is to set environment variables
+  `XDG_CONFIG_HOME=/tmp/.chrome` and `XDG_CACHE_HOME=/tmp/.chrome` on the Grafana
+  process. If users do not wish to use `/tmp`, any folder where Grafana process
+  has write permissions can be used.
 
 - If you get `permission denied` response when generating a report, it is due to the
   user not having `View` permissions on the dashboard that they are attempting to generate


### PR DESCRIPTION
* Using capture screenshot API of chromedp, we can generate PNG of each panel using current plugin. Thus, we avoid the dependency with grafana-image-renderer

* Move all panel related JS to a separate .js file and embed that file with the app. Read the file content at runtime and inject it into chrome tab tasks.

* Add duration debug logs for better debugging experience

* Add e2e tests to test both native renderer and grafana-image-renderer integrations