### PR TITLE
Testing of chromium distributed by grafana-image-renderer

### DIFF
--- a/pkg/plugin/dashboard/panels_test.go
+++ b/pkg/plugin/dashboard/panels_test.go
@@ -50,20 +50,6 @@ func TestDashboardFetchWithLocalChrome(t *testing.T) {
 	}
 
 	Convey("When fetching a Dashboard", t, func() {
-		// Get CWD
-		cwd, err := os.Getwd()
-
-		Convey("getting CWD should not error", func() {
-			So(err, ShouldBeNil)
-		})
-
-		// Read sample HTML file
-		data, err := os.ReadFile(filepath.Join(cwd, "testdata/dashboard.html"))
-
-		Convey("setup a dashboard HTML page should not error", func() {
-			So(err, ShouldBeNil)
-		})
-
 		chromeInstance, err := chrome.NewLocalBrowserInstance(context.Background(), log.NewNullLogger(), true)
 		defer chromeInstance.Close(log.NewNullLogger()) //nolint:staticcheck
 
@@ -76,6 +62,22 @@ func TestDashboardFetchWithLocalChrome(t *testing.T) {
 		requestCookie := ""
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Get CWD
+			cwd, err := os.Getwd()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
+			// Read sample HTML file
+			data, err := os.ReadFile(filepath.Join(cwd, "testdata/dashboard.html"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
 			muLock.Lock()
 			requestURI = append(requestURI, r.RequestURI)
 			requestCookie = r.Header.Get(backend.CookiesHeaderName)
@@ -149,20 +151,6 @@ func TestDashboardFetchWithRemoteChrome(t *testing.T) {
 	}
 
 	Convey("When fetching a Dashboard", t, func() {
-		// Get CWD
-		cwd, err := os.Getwd()
-
-		Convey("getting CWD should not error", func() {
-			So(err, ShouldBeNil)
-		})
-
-		// Read sample HTML file
-		data, err := os.ReadFile(filepath.Join(cwd, "testdata/dashboard.html"))
-
-		Convey("setup a dashboard HTML page should not error", func() {
-			So(err, ShouldBeNil)
-		})
-
 		chromeInstance, err := chrome.NewRemoteBrowserInstance(
 			context.Background(),
 			log.NewNullLogger(),
@@ -178,6 +166,22 @@ func TestDashboardFetchWithRemoteChrome(t *testing.T) {
 		requestCookie := ""
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Get CWD
+			cwd, err := os.Getwd()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
+			// Read sample HTML file
+			data, err := os.ReadFile(filepath.Join(cwd, "testdata/dashboard.html"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
 			muLock.Lock()
 			requestURI = append(requestURI, r.RequestURI)
 			requestCookie = r.Header.Get(backend.CookiesHeaderName)


### PR DESCRIPTION
* We need to do some basic test using chromium shipped by Grafana image renderer before using it. We were testing it using `--help` flag which does not exist on the application. If it works, it hangs which is not what we want.

* This commit fixes this test by using a command that returns upon successful execution. We also use a timeout just in case to avoid the command hanging in there forever.

* We also setup a special home directory for chromium and inject `XDG_CONFIG_HOME` and `XDG_CONFIG_HOME` env vars in chromium process. This avoids chromium attempting to create directories in read-only folders.