### PR TITLE
Ensure to respect the panel width in grid layout

### DIFF
--- a/.ci/datasources/sample.yml
+++ b/.ci/datasources/sample.yml
@@ -12,4 +12,6 @@ datasources:
       timeInterval: 10s
     name: Prometheus
     type: prometheus
-    url: https://prometheus.demo.do.prometheus.io
+    # Seems like Prometheus demo can go down. So we are
+    # using our own instance
+    url: http://ceems-demo.myaddr.tools:9090

--- a/.ci/datasources/sample.yml
+++ b/.ci/datasources/sample.yml
@@ -14,4 +14,4 @@ datasources:
     type: prometheus
     # Seems like Prometheus demo can go down. So we are
     # using our own instance
-    url: http://ceems-demo.myaddr.tools:9090
+    url: https://ceems-demo.myaddr.tools:9443

--- a/.github/workflows/step_lint.yml
+++ b/.github/workflows/step_lint.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.3
+          version: v1.63.4
           args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - dupword
     - exhaustruct
     - exportloopref
-    - gomnd
     - gocognit
     - gocyclo
     - gocritic
@@ -17,7 +16,6 @@ linters:
     - funlen
     - ireturn
     - err113
-    - execinquery
     - mnd
     - nestif
     - testpackage
@@ -50,3 +48,19 @@ linters-settings:
       - name: unused-parameter
         severity: warning
         disabled: true
+  recvcheck:
+    # Disables the built-in method exclusions:
+    # - `MarshalText`
+    # - `MarshalJSON`
+    # - `MarshalYAML`
+    # - `MarshalXML`
+    # - `MarshalBinary`
+    # - `GobEncode`
+    # Default: false
+    disable-builtin: true
+    # User-defined method exclusions.
+    # The format is `struct_name.method_name` (ex: `Foo.MethodName`).
+    # A wildcard `*` can use as a struct name (ex: `*.MethodName`).
+    # Default: []
+    exclusions:
+      - "*.String"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.4.0}
+        grafana_version: ${GRAFANA_VERSION:-11.5.0}
         development: ${DEVELOPMENT:-false}
         go_version: ${GOVERSION:-1.23.2}
     cap_add:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - GF_SERVER_HTTP_PORT=${GF_SERVER_HTTP_PORT:-3000}
       - GF_LOG_LEVEL=${GF_LOG_LEVEL:-info}
       - GF_DATAPROXY_LOGGING=true
+      - GF_DATAPROXY_SEND_USER_HEADER=true
       # allow anonymous admin so we don't have to set up a password to start testing
       - GF_AUTH_ANONYMOUS_ENABLED=${GF_AUTH_ANONYMOUS_ENABLED:-false}
       - GF_AUTH_LOGIN_COOKIE_NAME=${GF_AUTH_LOGIN_COOKIE_NAME:-grafana_session}

--- a/pkg/plugin/dashboard/panels.go
+++ b/pkg/plugin/dashboard/panels.go
@@ -152,6 +152,7 @@ func (d *Dashboard) createPanels(dashData []interface{}) ([]Panel, error) {
 	maxWidth := float64(viewportWidth)
 
 	// Iterate over the slice of interfaces and build each panel
+	// Playground: https://goplay.tools/snippet/-cAljARG2Gj
 	for _, panelData := range dashData {
 		var p Panel
 

--- a/pkg/plugin/dashboard/panels.go
+++ b/pkg/plugin/dashboard/panels.go
@@ -149,7 +149,7 @@ func (d *Dashboard) createPanels(dashData []interface{}) ([]Panel, error) {
 	// Start off with maxWidth as viewportWidth. If not for dashboards that do not
 	// occupy full width, our internal positioning method will "strech" these dashboards
 	// to full width.
-	var maxWidth = float64(viewportWidth)
+	maxWidth := float64(viewportWidth)
 
 	// Iterate over the slice of interfaces and build each panel
 	for _, panelData := range dashData {

--- a/pkg/plugin/dashboard/panels.go
+++ b/pkg/plugin/dashboard/panels.go
@@ -145,7 +145,11 @@ func (d *Dashboard) createPanels(dashData []interface{}) ([]Panel, error) {
 	// Max Width = Max X + Width for that element
 	// We divide this maxWidth in 24 columns as done in Grafana to calculate Panel
 	// coordinates
-	var maxWidth float64
+	//
+	// Start off with maxWidth as viewportWidth. If not for dashboards that do not
+	// occupy full width, our internal positioning method will "strech" these dashboards
+	// to full width.
+	var maxWidth = float64(viewportWidth)
 
 	// Iterate over the slice of interfaces and build each panel
 	for _, panelData := range dashData {

--- a/pkg/plugin/dashboard/renderer.go
+++ b/pkg/plugin/dashboard/renderer.go
@@ -192,15 +192,21 @@ func (d *Dashboard) panelPNGURL(p Panel, render bool) *url.URL {
 
 // panelDims returns width and height of panel based on layout.
 func (d *Dashboard) panelDims(p Panel) (int64, int64) {
-	// If using a grid layout we use 100px for width and 36px for height scalind.
-	// Grafana panels are fitted into 24 units width and height units are said to
-	// 30px in docs but 36px seems to be better.
+	// According to Grafana docs, width scaling is ~80px and height
+	// scaling is ~36px. However, on grid layout these scales render
+	// panels that are too small to read. With some trial and error
+	// we figured out that using 64px for width renders decent result
+	// without too much distortion.
+	//
+	// From rudimentary tests, seems like Grafana cloud offering using
+	// even smaller width scaling which is evident in distored aspect
+	// ratios of some panels when grid layout is chosen.
 	//
 	// In simple layout we create panels with 1000x500 resolution always and include
 	// them one in each page of report
 	var width, height int64
 	if d.conf.Layout == "grid" {
-		width = int64(p.GridPos.W * 100)
+		width = int64(p.GridPos.W * 64)
 		height = int64(p.GridPos.H * 36)
 	} else {
 		width = 1000

--- a/pkg/plugin/dashboard/renderer_test.go
+++ b/pkg/plugin/dashboard/renderer_test.go
@@ -140,7 +140,7 @@ func TestFetchPanelPNG(t *testing.T) {
 		})
 
 		Convey("The httpClient should request singlestat panels at grid layout size", func() {
-			So(requestURI, ShouldContainSubstring, "width=2400")
+			So(requestURI, ShouldContainSubstring, "width=1536")
 			So(requestURI, ShouldContainSubstring, "height=216")
 		})
 	})

--- a/pkg/plugin/dashboard/types.go
+++ b/pkg/plugin/dashboard/types.go
@@ -138,27 +138,27 @@ func (p *Panel) UnmarshalJSON(b []byte) error {
 }
 
 // IsSingleStat returns true if panel is of type SingleStat.
-func (p Panel) IsSingleStat() bool {
+func (p *Panel) IsSingleStat() bool {
 	return p.Is(SingleStat)
 }
 
 // IsPartialWidth If panel has width less than total allowable width.
-func (p Panel) IsPartialWidth() bool {
+func (p *Panel) IsPartialWidth() bool {
 	return (p.GridPos.W < 24)
 }
 
 // Width returns the width of the panel.
-func (p Panel) Width() float64 {
+func (p *Panel) Width() float64 {
 	return float64(p.GridPos.W) * 0.04
 }
 
 // Height returns the height of the panel.
-func (p Panel) Height() float64 {
+func (p *Panel) Height() float64 {
 	return float64(p.GridPos.H) * 0.04
 }
 
 // Is returns true if panel is of type t.
-func (p Panel) Is(t PanelType) bool {
+func (p *Panel) Is(t PanelType) bool {
 	return p.Type == t.string()
 }
 

--- a/src/README.md
+++ b/src/README.md
@@ -213,13 +213,14 @@ This config section allows to configure report related settings.
 - `file:theme; env:GF_REPORTER_PLUGIN_REPORT_THEME; ui:Theme`: Theme of the panels in
   the report.
 
+- `file:orientation; env:GF_REPORTER_PLUGIN_REPORT_ORIENTATION; ui:Orientation`: Orientation
+  of the report. Available options: `portrait` and `landscape`.
+
 - `file:layout; env:GF_REPORTER_PLUGIN_REPORT_LAYOUT; ui:Layout`: Layout of the report.
   Using grid layout renders the report as it is rendered in the browser. A simple
   layout will render the report with one panel per row. Available options: `simple`
-  and `grid`.
-
-- `file:orientation; env:GF_REPORTER_PLUGIN_REPORT_ORIENTATION; ui:Orientation`: Orientation
-  of the report. Available options: `portrait` and `landscape`.
+  and `grid`. When using `grid` layout, we recommend to use `landscape` orientation
+  for better readability.
 
 - `file:dashboardMode; env:GF_REPORTER_PLUGIN_REPORT_DASHBOARD_MODE; ui:Dashboard Mode`:
   Whether to render default dashboard or full dashboard. In default mode, collapsed rows


### PR DESCRIPTION
* If dashboards contains panels that do not use full width, the reporter will stretch them to use full width. This happens only when none of the panels in the dashboard use full width which is sort of rare. To handle this edge case, we start setting maxWidth as view port width to ensure we respect dashboard panels width.

* Replace Prometheus demo by Prometheus instance used on CEEMS demo server. Seems like Prometheus demo is offline

Closes #272 