### PR TITLE
Avoid loading data when fetching panels metadata

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
         grafana_version: ${GRAFANA_VERSION:-11.6.0}
         development: ${DEVELOPMENT:-false}
-        go_version: ${GOVERSION:-1.23.2}
+        go_version: ${GOVERSION:-1.24.2}
     cap_add:
       - SYS_PTRACE
     ports:

--- a/pkg/plugin/chrome/helpers.go
+++ b/pkg/plugin/chrome/helpers.go
@@ -50,7 +50,7 @@ func waitFor(eventName string) chromedp.ActionFunc {
 	return func(ctx context.Context) error {
 		ch := make(chan struct{})
 		cctx, cancel := context.WithCancel(ctx)
-		chromedp.ListenTarget(cctx, func(ev interface{}) {
+		chromedp.ListenTarget(cctx, func(ev any) {
 			switch e := ev.(type) {
 			case *page.EventLifecycleEvent:
 				if e.Name == eventName {

--- a/pkg/plugin/chrome/stream.go
+++ b/pkg/plugin/chrome/stream.go
@@ -47,11 +47,9 @@ func (reader *streamReader) Read(p []byte) (int, error) {
 	// Chromium might have an off-by-one when deciding the maximum size (at
 	// least for base64 encoded data), usually it will overflow. We subtract
 	// one to make sure it fits into p.
-	size := len(p) - 1
-	if size < 1 {
+	size := max(len(p)-1,
 		// Safety-check to avoid crashing Chrome (e.g. via SetSize(-1)).
-		size = 1
-	}
+		1)
 
 	reply, err := reader.next(reader.pos, size)
 	if err != nil {

--- a/pkg/plugin/chrome/tab.go
+++ b/pkg/plugin/chrome/tab.go
@@ -15,6 +15,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Default URLs to block.
+var (
+	defaultBlockedURLs = []string{"*/api/frontend-metrics", "*/api/live/ws", "*/api/user/*"}
+)
+
 var WithAwaitPromise = func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithAwaitPromise(true)
 }
@@ -46,10 +51,10 @@ func (t *Tab) Close(logger log.Logger) {
 }
 
 // NavigateAndWaitFor navigates to the given address and waits for the given event to be fired on the page.
-func (t *Tab) NavigateAndWaitFor(addr string, headers map[string]any, eventName string) error {
+func (t *Tab) NavigateAndWaitFor(addr string, headers map[string]any, eventName string, blockedURLs []string) error {
 	if err := t.Run(
 		// block some URLs to avoid unnecessary requests
-		network.SetBlockedURLs([]string{"*/api/frontend-metrics", "*/api/live/ws", "*/api/user/*"}),
+		network.SetBlockedURLs(append(defaultBlockedURLs, blockedURLs...)),
 		enableLifeCycleEvents(),
 	); err != nil {
 		return fmt.Errorf("error enable lifecycle events: %w", err)

--- a/pkg/plugin/dashboard/data.go
+++ b/pkg/plugin/dashboard/data.go
@@ -38,7 +38,7 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 		}
 	}
 
-	err := tab.NavigateAndWaitFor(panelURL, headers, "networkIdle")
+	err := tab.NavigateAndWaitFor(panelURL, headers, "networkIdle", nil)
 	if err != nil {
 		return nil, fmt.Errorf("NavigateAndWaitFor: %w", err)
 	}
@@ -50,7 +50,7 @@ func (d *Dashboard) PanelCSV(_ context.Context, p Panel) (CSVData, error) {
 	errCh := make(chan error, 1)
 
 	// Listen for download events. Downloading from JavaScript won't emit any network events.
-	chromedp.ListenTarget(tab.Context(), func(event interface{}) {
+	chromedp.ListenTarget(tab.Context(), func(event any) {
 		if eventDownloadWillBegin, ok := event.(*browser.EventDownloadWillBegin); ok {
 			d.logger.Debug("got CSV download URL", "panel_id", p.ID, "url", eventDownloadWillBegin.URL)
 			// once we have the download URL, we can fetch the CSV data via JavaScript.

--- a/pkg/plugin/dashboard/panels_test.go
+++ b/pkg/plugin/dashboard/panels_test.go
@@ -275,7 +275,7 @@ func TestDashboardCreatePanels(t *testing.T) {
 
 		dashDataString := `[{"width":940,"height":258,"x":0,"y":0,"id":"12"},{"width":940,"height":258,"x":940,"y":0,"id":"26"},{"width":940,"height":258,"x":0,"y":0,"id":"27"}]`
 
-		var dashData []interface{}
+		var dashData []any
 		err = json.Unmarshal([]byte(dashDataString), &dashData)
 
 		Convey("setup dashboard data unmarshal", func() {

--- a/pkg/plugin/dashboard/renderer.go
+++ b/pkg/plugin/dashboard/renderer.go
@@ -47,7 +47,7 @@ func (d *Dashboard) panelPNGNativeRenderer(_ context.Context, p Panel) (PanelIma
 		}
 	}
 
-	err := tab.NavigateAndWaitFor(panelURL, headers, "networkIdle")
+	err := tab.NavigateAndWaitFor(panelURL, headers, "networkIdle", nil)
 	if err != nil {
 		return PanelImage{}, fmt.Errorf("NavigateAndWaitFor: %w", err)
 	}

--- a/pkg/plugin/dashboard/time_test.go
+++ b/pkg/plugin/dashboard/time_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func sameTimeAs(actual interface{}, expected ...interface{}) string {
+func sameTimeAs(actual any, expected ...any) string {
 	if actual == expected[0] {
 		return ""
 	} else {

--- a/pkg/plugin/dashboard/types.go
+++ b/pkg/plugin/dashboard/types.go
@@ -87,7 +87,7 @@ type GridPos struct {
 type PanelID string
 
 func (i *PanelID) UnmarshalJSON(b []byte) error {
-	var item interface{}
+	var item any
 	if err := json.Unmarshal(b, &item); err != nil {
 		return err
 	}

--- a/pkg/plugin/helpers/helpers.go
+++ b/pkg/plugin/helpers/helpers.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TimeTrack tracks execution time of each function.
-func TimeTrack(start time.Time, name string, logger log.Logger, args ...interface{}) {
+func TimeTrack(start time.Time, name string, logger log.Logger, args ...any) {
 	elapsed := time.Since(start)
 	args = append(args, "duration", elapsed.String())
 	logger.Debug(name, args...)


### PR DESCRIPTION
* When fetching panels metadata, we dont need the queries to fetch the data from underlying datasource. We can simply add datasource API to blockedURLs so that we get the networkIdle event faster. This can be really useful when loading huge dashboards with a lot of panels and data.

* Run go modernise over entire package

Fixes #381