### PR TITLE
Repeated panels using query based variable

### DIFF
--- a/.github/workflows/step_e2e-tests.yml
+++ b/.github/workflows/step_e2e-tests.yml
@@ -72,12 +72,12 @@ jobs:
             name: local-chrome-11.6.0-with-features-native-renderer
 
           # Latest Grafana v12.x with remote chrome and native-renderer
-          - grafana-version: 12.0.2
+          - grafana-version: 12.2.0
             remote-chrome-url: ws://localhost:9222
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
             native-rendering: true
             # snapshots-folder: remote-chrome
-            name: remote-chrome-12.0.2-with-features-native-renderer
+            name: remote-chrome-12.2.0-with-features-native-renderer
 
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.6.0}
+        grafana_version: ${GRAFANA_VERSION:-12.2.0}
         development: ${DEVELOPMENT:-false}
         go_version: ${GOVERSION:-1.24.2}
     cap_add:

--- a/pkg/plugin/chrome/local.go
+++ b/pkg/plugin/chrome/local.go
@@ -154,6 +154,7 @@ func NewLocalBrowserInstance(ctx context.Context, logger log.Logger, insecureSki
 	browserCtx, _ := chromedp.NewContext(allocCtx,
 		chromedp.WithErrorf(chromeLogger.Error),
 		chromedp.WithLogf(chromeLogger.Debug),
+		// chromedp.WithDebugf(chromeLogger.Debug),
 	)
 
 	if err := chromedp.Run(browserCtx); err != nil {

--- a/pkg/plugin/chrome/tab.go
+++ b/pkg/plugin/chrome/tab.go
@@ -16,6 +16,21 @@ import (
 )
 
 // Default URLs to block.
+/*
+	When dashboards use datasources that rely on Grafana Live like MQTT,
+	we need to unblock /api/live/ws endpoint. However, it is observed that
+	Grafana does not forward Authorization header to /api/live/ws endpoint
+	when rendering individual panel and thus, websocket handshake would never
+	be finished and we never get panel rendered.
+
+	Unfortunately, chromedp's fetch method does not intercept websocket
+	requests to be able to inject the headers and so we cannot render
+	panels with live in native mode.
+
+	Refs:
+	- https://issues.chromium.org/issues/40923369#comment9
+	- https://github.com/chromedp/chromedp/issues/805
+*/
 var (
 	defaultBlockedURLs = []string{"*/api/frontend-metrics", "*/api/live/ws", "*/api/user/*"}
 )

--- a/pkg/plugin/dashboard/panels.go
+++ b/pkg/plugin/dashboard/panels.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"time"
 
@@ -50,6 +51,13 @@ var (
 	viewportHeight int64 = 10800
 )
 
+// Starting from Grafana v11.3.0, repeated panels will get panel-1-clone-0, panel-2-clone-1
+// suffixes instead of number IDs for panels. When comparing the panel, we need
+// to retreive the ID from the string.
+var (
+	panelIDRegex = regexp.MustCompile("panel-([0-9]+)(?:.*)")
+)
+
 // panels fetches dashboard panels from Grafana chromium browser instance.
 func (d *Dashboard) panels(ctx context.Context) ([]Panel, error) {
 	// Fetch dashboard data from browser
@@ -84,7 +92,10 @@ func (d *Dashboard) panelMetaData(_ context.Context) ([]any, error) {
 		}
 	}
 
-	err := tab.NavigateAndWaitFor(dashURL, headers, "networkIdle", []string{"*/api/ds/query*"})
+	// We dont need to load data from backend datasources to get panels metadata.
+	// Similarly there is no need of Grafana live for fetching metadata.
+	// So block both of them as they can hinder firing networkIdle event.
+	err := tab.NavigateAndWaitFor(dashURL, headers, "networkIdle", []string{"*/api/ds/query*", "*/api/live/ws"})
 	if err != nil {
 		return nil, fmt.Errorf("NavigateAndWaitFor: %w", err)
 	}
@@ -202,26 +213,40 @@ func (d *Dashboard) createPanels(dashData []any) ([]Panel, error) {
 			continue
 		}
 
-		// // Populate Type and Title from dashboard JSON model
-		// for _, rowOrPanel := range d.model.Dashboard.RowOrPanels {
-		// 	if rowOrPanel.Type == "row" {
-		// 		for _, rp := range rowOrPanel.Panels {
-		// 			if rp.ID == p.ID {
-		// 				p.Type = rp.Type
-		// 				p.Title = rp.Title
+		// Retrive numeric ID from panel.ID
+		var pID string
 
-		// 				break
-		// 			}
-		// 		}
-		// 	} else {
-		// 		if p.ID == rowOrPanel.ID {
-		// 			p.Type = rowOrPanel.Type
-		// 			p.Title = rowOrPanel.Title
+		if matches := panelIDRegex.FindStringSubmatch(p.ID); len(matches) > 1 {
+			pID = matches[1]
+		} else {
+			pID = p.ID
+		}
 
-		// 			break
-		// 		}
-		// 	}
-		// }
+		// Populate Repeat var from dashboard JSON model
+		for _, rowOrPanel := range d.model.Dashboard.RowOrPanels {
+			if rowOrPanel.Type == "row" {
+				for _, rp := range rowOrPanel.Panels {
+					if rp.ID == pID {
+						p.Repeat = rp.Repeat
+
+						break
+					}
+				}
+			} else {
+				if rowOrPanel.ID == pID {
+					p.Repeat = rowOrPanel.Repeat
+
+					break
+				}
+			}
+		}
+
+		// Check if panel has repeat variable and repeat variable is set to $__all, ignore all
+		// clones except the first one
+		// NOTE: Workaround until https://github.com/grafana/grafana/issues/108754 gets fixed
+		if p.Repeat != "" && d.model.Dashboard.Variables.Get("var-"+p.Repeat) == "$__all" && !strings.Contains(p.ID, "clone-0") {
+			continue
+		}
 
 		// Create panel model and append to panels
 		panels = append(panels, p)

--- a/pkg/plugin/dashboard/renderer.go
+++ b/pkg/plugin/dashboard/renderer.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/runtime"
@@ -162,8 +163,32 @@ func (d *Dashboard) panelPNGImageRenderer(ctx context.Context, p Panel) (PanelIm
 // panelPNGURL returns the URL to fetch panel PNG.
 func (d *Dashboard) panelPNGURL(p Panel, render bool) string {
 	values := maps.Clone(d.model.Dashboard.Variables)
+	pID := p.ID
+
+	// Starting from Grafana v11.3.0, repeated panels will have clone in
+	// their IDs but we need to strip it down and repeat the panel ID with
+	// each var. If var is $__all, there is nothing we can do, just pass
+	// it through and all panels will be overlapped.
+	//
+	// Panel IDs will be of format panel-10-clone-0
+	// Split by -clone- and get first and second parts
+	//
+	// NOTE: Workaround until https://github.com/grafana/grafana/issues/108754 gets fixed
+	parts := strings.Split(p.ID, "-clone-")
+
+	if p.Repeat != "" && len(parts) == 2 {
+		pID = parts[0]
+		if i, err := strconv.Atoi(parts[1]); err == nil {
+			varKey := fmt.Sprintf("var-%s", p.Repeat)
+			if varValues := values[varKey]; len(varValues) > 1 && i < len(varValues) {
+				values.Del(varKey)
+				values.Set(varKey, varValues[i])
+			}
+		}
+	}
+
 	values.Add("theme", d.conf.Theme)
-	values.Add("panelId", p.ID)
+	values.Add("panelId", pID)
 
 	if d.conf.TimeZone != "" && values.Get("timezone") == "" {
 		values.Add("timezone", d.conf.TimeZone)

--- a/pkg/plugin/dashboard/types.go
+++ b/pkg/plugin/dashboard/types.go
@@ -110,12 +110,13 @@ type Panel struct {
 	Type         string  `json:"type"`
 	Title        string  `json:"title"`
 	GridPos      GridPos `json:"gridPos"`
+	Repeat       string  `json:"repeat"`
 	EncodedImage PanelImage
 	CSVData      CSVData
 }
 
 func (p *Panel) String() string {
-	return fmt.Sprintf("Panel ID: %s and Title: %s", p.ID, p.Title)
+	return fmt.Sprintf("Panel ID: %s; Title: %s; Repeat: %s", p.ID, p.Title, p.Repeat)
 }
 
 func (p *Panel) UnmarshalJSON(b []byte) error {

--- a/src/README.md
+++ b/src/README.md
@@ -584,6 +584,16 @@ apps:
 > These settings can be configured only through provisioned config file and it is not
 possible to set them using either environment variables or Grafana UI.
 
+## Limitations
+
+- Due to a [bug](https://github.com/grafana/grafana/issues/108754) in Grafana, there exists
+a limitation for the reports generated for dashboards with repeated panels using query based variable.
+If variable `All` in selected for generating report with repeated panels, all the data will be
+included in the same panel instead of generating a panel for each different variable. This cannot
+be fixed until the bug in upstream Grafana is fixed. A workaround is to select all the variables
+in the dashboard instead of selecting `All` which will generate different panel for each variable
+in the report.
+
 ## Troubleshooting
 
 - When TLS is enabled on Grafana server, `grafana-image-renderer` tends to throw

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,7 +37,7 @@
       "type": "page",
       "name": "Status",
       "path": "/a/%PLUGIN_ID%/status",
-      "role": "Viewer",
+      "role": "Admin",
       "addToNav": true,
       "defaultNav": true
     },
@@ -47,7 +47,7 @@
       "name": "Configuration",
       "path": "/plugins/%PLUGIN_ID%",
       "role": "Admin",
-      "addToNav": false
+      "addToNav": true
     }
   ],
   "dependencies": {


### PR DESCRIPTION
* Seems like due to bug in upstream Grafana, repeated panels that use query based variable cannot be rendered properly. The current fix is a workaround until Grafana fixes the issue upstream

* Add plugin to nav bar only for Admin users as it does not add any value for regular users.

* Bump Grafana 12.x to 12.2.0 in e2e tests

Fixes #386 
Fixes #390