### PR TITLE
fix: Update Grafana renderer config in dev env

### DIFF
--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -1,14 +1,14 @@
-version: '3.0'
+version: "3.0"
 
 services:
   grafana_plain:
     # image: grafana/grafana:latest
-    container_name: 'mahendrapaipuri-dashboardreporter-app-plain'
+    container_name: "mahendrapaipuri-dashboardreporter-app-plain"
     build:
       context: ../.config
       args:
-        grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.4.0}
+        grafana_image: ${GRAFANA_IMAGE:-grafana}
+        grafana_version: ${GRAFANA_VERSION:-12.3.0}
     ports:
       - 3080:${GF_SERVER_HTTP_PORT:-3000}/tcp
     volumes:
@@ -57,13 +57,7 @@ services:
   renderer_plain:
     image: grafana/grafana-image-renderer:latest
     environment:
-      # Recommendation of grafana-image-renderer for optimal performance
-      # https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#configuration
-      - RENDERING_MODE=clustered
-      - RENDERING_CLUSTERING_MODE=browser
-      - RENDERING_CLUSTERING_MAX_CONCURRENCY=5
-      - RENDERING_CLUSTERING_TIMEOUT=600
-      - IGNORE_HTTPS_ERRORS=true
+      - BROWSER_FLAG=--ignore-certificate-errors
 
   chrome_plain:
     image: chromedp/headless-shell:latest
@@ -73,12 +67,12 @@ services:
 
   grafana_tls:
     # image: grafana/grafana:latest
-    container_name: 'mahendrapaipuri-dashboardreporter-app-tls'
+    container_name: "mahendrapaipuri-dashboardreporter-app-tls"
     build:
       context: ../.config
       args:
-        grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-11.4.0}
+        grafana_image: ${GRAFANA_IMAGE:-grafana}
+        grafana_version: ${GRAFANA_VERSION:-12.3.0}
     ports:
       - 3443:${GF_SERVER_HTTP_PORT:-3000}/tcp
     volumes:
@@ -112,7 +106,7 @@ services:
       - GF_UNIFIED_ALERTING_ENABLED=false
       - GF_LIVE_MAX_CONNECTIONS=0
       - GF_PLUGINS_DISABLE_PLUGINS=grafana-lokiexplore-app
-       # TLS
+        # TLS
       - GF_SERVER_PROTOCOL=https
       - GF_SERVER_CERT_KEY=/etc/grafana/tls/localhost.key
       - GF_SERVER_CERT_FILE=/etc/grafana/tls/localhost.crt
@@ -128,16 +122,10 @@ services:
       - GF_REPORTER_PLUGIN_SKIP_TLS_CHECK=true
 
   renderer_tls:
-    image: grafana/grafana-image-renderer:latest
+    image: grafana/grafana-image-renderer:latest # localhost/renderer:latest
     environment:
-      # Recommendation of grafana-image-renderer for optimal performance
-      # https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#configuration
-      - RENDERING_MODE=clustered
-      - RENDERING_CLUSTERING_MODE=browser
-      - RENDERING_CLUSTERING_MAX_CONCURRENCY=5
-      - RENDERING_CLUSTERING_TIMEOUT=600
-      - IGNORE_HTTPS_ERRORS=true
-  
+      - BROWSER_FLAG=--ignore-certificate-errors
+
   chrome_tls:
     image: chromedp/headless-shell:latest
     shm_size: 2G
@@ -145,4 +133,4 @@ services:
     network_mode: service:grafana_tls
     # We need to manually setup chrome instance as default entrypoint does not have --ignore-certificate-errors flag
     entrypoint: /headless-shell/headless-shell
-    command: --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --disable-gpu --headless --no-sandbox --ignore-certificate-errors=1
+    command: --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --disable-gpu --headless --no-sandbox --ignore-certificate-errors

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,12 @@
 services:
   grafana:
     # image: grafana/grafana:latest
-    container_name: 'mahendrapaipuri-dashboardreporter-app'
+    container_name: "mahendrapaipuri-dashboardreporter-app"
     build:
       context: ./.config
       args:
-        grafana_image: ${GRAFANA_IMAGE:-grafana-oss}
-        grafana_version: ${GRAFANA_VERSION:-12.1.0}
+        grafana_image: ${GRAFANA_IMAGE:-grafana}
+        grafana_version: ${GRAFANA_VERSION:-12.3.0}
         development: ${DEVELOPMENT:-false}
         go_version: ${GOVERSION:-1.24.2}
     cap_add:
@@ -55,17 +55,9 @@ services:
   renderer:
     image: grafana/grafana-image-renderer:latest
     environment:
-      # Recommendation of grafana-image-renderer for optimal performance
-      # https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#configuration
-      - RENDERING_MODE=clustered
-      - RENDERING_CLUSTERING_MODE=context
-      - RENDERING_CLUSTERING_MAX_CONCURRENCY=5
-      - RENDERING_CLUSTERING_TIMEOUT=60
-      - IGNORE_HTTPS_ERRORS=true
-      # - RENDERING_ARGS=--no-sandbox,--disable-setuid-sandbox,--disable-dev-shm-usage,--disable-accelerated-2d-canvas,--disable-gpu,--remote-debugging-port=9090
+      - BROWSER_FLAG=--ignore-certificate-errors
     ports:
       - 8081
-      # - 9090
   chrome:
     image: chromedp/headless-shell:latest
     shm_size: 2G

--- a/src/README.md
+++ b/src/README.md
@@ -35,7 +35,7 @@ a more recent version of `chromium` as few issues were noticed with `chromium <=
 > Using `grafana-image-renderer` as Grafana plugin is deprecated and there is a known
 [bug](https://github.com/grafana/grafana-image-renderer/issues/815) from the version
 `4.0.17` that makes the plugin unusable. Therefore, users must install a version `<= 4.0.16`
-or use Grafana image renderer as an external service. 
+or use Grafana image renderer as an external service.
 
 ## Installation
 
@@ -621,7 +621,8 @@ error messages will be as follows:
   ```
 
   To solve this issue set environment variables `GF_RENDERER_PLUGIN_IGNORE_HTTPS_ERRORS=true`
-  and `IGNORE_HTTPS_ERRORS=true` for the `grafana-image-renderer` service.
+  and `IGNORE_HTTPS_ERRORS=true` for the `grafana-image-renderer < 5` and for `grafana-image-renderer >= 5`,
+	set variable `BROWSER_FLAG=--ignore-certificate-errors` on renderer service.
 
 - If `chromium` fails to run, it suggests that there are missing dependent libraries on
 the host. In that case, we advise to install `chromium` on the machine which will


### PR DESCRIPTION
* Grafana image renderer moved to complete go package using chromedp. This means config parameters are no longer working and we need to update it for newer version