### PR TITLE
feat: Support HTML report format

### DIFF
--- a/.github/workflows/step_e2e-tests.yml
+++ b/.github/workflows/step_e2e-tests.yml
@@ -27,6 +27,7 @@ jobs:
             remote-chrome-url: ''
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
             native-rendering: true
+            format: html
             # snapshots-folder: local-chrome
             name: local-chrome-10.4.5-with-features
 
@@ -44,6 +45,7 @@ jobs:
             remote-chrome-url: ws://localhost:9222
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
             native-rendering: false
+            format: html
             # snapshots-folder: remote-chrome
             name: remote-chrome-11.1.0-with-features
 
@@ -87,6 +89,7 @@ jobs:
             feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
             # snapshots-folder: remote-chrome
             forward-host-env-vars: mahendrapaipuri-dashboardreporter-app
+            format: html
             name: local-chrome-12.4.0-with-features
 
           # Latest Grafana v13.x with remote chrome and native-renderer
@@ -95,6 +98,14 @@ jobs:
             # snapshots-folder: remote-chrome
             forward-host-env-vars: mahendrapaipuri-dashboardreporter-app
             name: local-chrome-13.0.1-with-features
+
+          # Latest Grafana v13.x with remote chrome and native-renderer
+          - grafana-version: 13.0.1
+            feature-flags: 'accessControlOnCall,idForwarding,externalServiceAccounts'
+            # snapshots-folder: remote-chrome
+            forward-host-env-vars: mahendrapaipuri-dashboardreporter-app
+            format: html
+            name: local-chrome-13.0.1-with-features-html
 
     steps:
       - uses: actions/checkout@v7
@@ -125,6 +136,7 @@ jobs:
           GF_REPORTER_PLUGIN_NATIVE_RENDERER: ${{ matrix.native-rendering }}
           GF_FEATURE_TOGGLES_ENABLE: ${{ matrix.feature-flags }}
           GF_PLUGINS_FORWARD_HOST_ENV_VARS: ${{ matrix.forward-host-env-vars }}
+          GF_REPORTER_PLUGIN_REPORT_FORMAT: ${{ matrix.format }}
         run: |
           # Upload/Download artifacts wont preserve permissions
           # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,11 @@ linters:
       - linters:
           - errcheck
         path: _test.go
+      - linters: 
+          - exhaustive
+          - intrange
+          - nilnil
+        path: node_modules
     paths:
       - third_party$
       - builtin$

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
-        grafana_version: ${GRAFANA_VERSION:-13.0.0}
+        grafana_version: ${GRAFANA_VERSION:-13.0}
         development: ${DEVELOPMENT:-false}
         go_version: ${GOVERSION:-1.24.2}
     cap_add:

--- a/pkg/plugin/config/settings.go
+++ b/pkg/plugin/config/settings.go
@@ -24,6 +24,7 @@ var (
 	validLayouts      = []string{"simple", "grid"}
 	validOrientations = []string{"portrait", "landscape"}
 	validModes        = []string{"default", "full"}
+	validFormats      = []string{"pdf", "html"}
 )
 
 // Config contains plugin settings.
@@ -45,6 +46,7 @@ type Config struct {
 	MaxRenderWorkers    int    `env:"GF_REPORTER_PLUGIN_MAX_RENDER_WORKERS, overwrite"          json:"maxRenderWorkers"`
 	RemoteChromeURL     string `env:"GF_REPORTER_PLUGIN_REMOTE_CHROME_URL, overwrite"           json:"remoteChromeUrl"`
 	NativeRendering     bool   `env:"GF_REPORTER_PLUGIN_NATIVE_RENDERER, overwrite"             json:"nativeRenderer"`
+	ReportFormat        string `env:"GF_REPORTER_PLUGIN_REPORT_FORMAT, overwrite"               json:"reportFormat"`
 	AppVersion          string `json:"appVersion"`
 	IncludePanelIDs     []string
 	ExcludePanelIDs     []string
@@ -80,6 +82,11 @@ func (c *Config) RTValidate() error {
 	// Check Mode
 	if !slices.Contains(validModes, c.DashboardMode) {
 		return fmt.Errorf("dashboard mode: %s must be one of [%s]", c.DashboardMode, strings.Join(validModes, ","))
+	}
+
+	// Check format
+	if !slices.Contains(validFormats, c.ReportFormat) {
+		return fmt.Errorf("report format: %s must be one of [%s]", c.ReportFormat, strings.Join(validFormats, ","))
 	}
 
 	// Set time zone to current server time zone if empty
@@ -197,11 +204,11 @@ func (c *Config) String() string {
 			"Time Zone: %s; Time Format: %s; Encoded Logo: %s; "+
 			"Max Renderer Workers: %d; Max Browser Workers: %d; Remote Chrome Addr: %s; App URL: %s; "+
 			"TLS Skip verify: %v; Included Panel IDs: %s; Excluded Panel IDs: %s Included Data for Panel IDs: %s; "+
-			"Native Renderer: %v; Client Timeout: %d",
+			"Native Renderer: %v; Client Timeout: %d; Report Format: %s",
 		c.Theme, c.Orientation, c.Layout, c.DashboardMode, c.TimeZone, c.TimeFormat,
 		encodedLogo, c.MaxRenderWorkers, c.MaxBrowserWorkers, c.RemoteChromeURL, appURL,
 		c.SkipTLSCheck, includedPanelIDs, excludedPanelIDs, includeDataPanelIDs, c.NativeRendering,
-		int(c.HTTPClientOptions.Timeouts.Timeout.Seconds()),
+		int(c.HTTPClientOptions.Timeouts.Timeout.Seconds()), c.ReportFormat,
 	)
 }
 
@@ -214,6 +221,7 @@ func Load(ctx context.Context, settings backend.AppInstanceSettings) (Config, er
 		Orientation:       "portrait",
 		Layout:            "simple",
 		DashboardMode:     "default",
+		ReportFormat:      "pdf",
 		TimeZone:          "",
 		TimeFormat:        "",
 		EncodedLogo:       "",

--- a/pkg/plugin/report/helpers.go
+++ b/pkg/plugin/report/helpers.go
@@ -21,6 +21,21 @@ func remove[T comparable](l []T, item T) []T {
 	return out
 }
 
+// normalizePanelID normalizes panel ID to be able to compare to user's input.
+func normalizePanelID(panelID string) string {
+	// Prior to Grafana 13.x, repeated panels used to have suffixes -clone-0, -clone-1, etc
+	panelID = strings.Split(panelID, "-clone")[0]
+	// From Grafana 13.x, we get panel IDs of format <var1>$<var2>$panel-3 for
+	// repeated panels based on variables. If we find "$" in panelID, we split
+	// it along $ and take the last value to get panel ID
+	if strings.Contains(panelID, "$") {
+		// Playground: https://go.dev/play/p/Jfj4FtbA2YF
+		panelID = panelID[strings.LastIndex(panelID, "$")+1:]
+	}
+
+	return panelID
+}
+
 // selectPanels returns panel indexes to render based on IncludePanelIDs and ExcludePanelIDs
 // config parameters.
 func selectPanels(panels []dashboard.Panel, includeIDs, excludeIDs []string, defaultInclude bool) []int {
@@ -30,7 +45,7 @@ func selectPanels(panels []dashboard.Panel, includeIDs, excludeIDs []string, def
 	// includeIDs
 	if len(includeIDs) == 0 && defaultInclude {
 		for _, p := range panels {
-			includeIDs = append(includeIDs, strings.Split(p.ID, "-clone")[0])
+			includeIDs = append(includeIDs, normalizePanelID(p.ID))
 		}
 	}
 
@@ -41,7 +56,7 @@ func selectPanels(panels []dashboard.Panel, includeIDs, excludeIDs []string, def
 
 		_, err := strconv.ParseInt(panel.ID, 10, 0)
 		if err != nil {
-			panelID = strings.Split(panel.ID, "-clone")[0]
+			panelID = normalizePanelID(panel.ID)
 		}
 
 		for _, id := range includeIDs {

--- a/pkg/plugin/report/report.go
+++ b/pkg/plugin/report/report.go
@@ -72,21 +72,26 @@ func (r *Report) Generate(ctx context.Context, writer http.ResponseWriter) error
 	// 	return panelTable.Data == nil
 	// })
 
-	// Sanitize title to escape non ASCII characters
-	// Ref: https://stackoverflow.com/questions/62705546/unicode-characters-in-attachment-name
-	// Ref: https://medium.com/@JeremyLaine/non-ascii-content-disposition-header-in-django-3a20acc05f0d
-	filename := url.PathEscape(dashboardData.Title)
-	header := fmt.Sprintf(`inline; filename*=UTF-8''%s.pdf`, filename)
-	writer.Header().Add("Content-Disposition", header)
-
 	htmlReport, err := r.generateHTMLFile(dashboardData)
 	if err != nil {
 		return fmt.Errorf("failed to generate HTML file: %w", err)
 	}
 
-	err = r.renderPDF(htmlReport, writer)
-	if err != nil {
-		return fmt.Errorf("failed to render PDF: %w", err)
+	if r.conf.ReportFormat == "html" {
+		writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(writer, htmlReport.Body)
+	} else {
+		// Sanitize title to escape non ASCII characters
+		// Ref: https://stackoverflow.com/questions/62705546/unicode-characters-in-attachment-name
+		// Ref: https://medium.com/@JeremyLaine/non-ascii-content-disposition-header-in-django-3a20acc05f0d
+		filename := url.PathEscape(dashboardData.Title)
+		header := fmt.Sprintf(`inline; filename*=UTF-8''%s.pdf`, filename)
+		writer.Header().Add("Content-Disposition", header)
+
+		err = r.renderPDF(htmlReport, writer)
+		if err != nil {
+			return fmt.Errorf("failed to render PDF: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/plugin/report/templates/report.gohtml
+++ b/pkg/plugin/report/templates/report.gohtml
@@ -12,16 +12,45 @@
     [data-theme="light"] {
         --color-bg: #ffffff;
         --color-fg: #000000;
+        --color-margin: lightgray;
     }
 
     [data-theme="dark"] {
         --color-bg: #181b1f;
         --color-fg: #ffffff;
+        --color-margin: #ffffff;
     }
 
     @page { 
         margin: 3cm 0cm 1cm 0cm;
         background-color: var(--color-bg);
+    }
+
+    .content-header {
+        width: 100%;
+        background-color: var(--color-bg);
+        color: var(--color-fg);
+        display: flex;
+        flex-wrap: wrap;
+        padding: 10px;
+        vertical-align: middle;
+        font-weight: bold;
+        font-size: 50px;
+        display: inline-block;
+        text-align: start;
+        border-bottom: 1px solid var(--color-margin);
+    }
+
+    .content-header-left {
+        font-weight: bold;
+        font-size: 20px;
+        float: left;
+    }
+
+    .content-header-right {
+        font-weight: bold;
+        font-size: 20px;
+        float: right;
     }
 
     html {
@@ -108,6 +137,18 @@
 </head>
 
 <body>
+    {{- if .IsHTMLFormat }}
+    <div class="content-header" data-theme="{{.Theme}}">
+        <div class="content-header-left" data-theme="{{.Theme}}">generated on {{.Date}}</div>
+        <div class="content-header-right" data-theme="{{.Theme}}">Datetime range: {{.From}} to {{.To}}</div>
+        <br />
+        {{ .Title }}
+        {{- if .VariableValues }}
+        <br />
+        <div class="content-header-left" data-theme="{{.Theme}}">{{ .VariableValues }}</div>
+        {{- end}}
+    </div>
+    {{- end }}
     <div class="container">
         <div class="grid">
             {{- range $i, $v := .Panels}}

--- a/pkg/plugin/report/types.go
+++ b/pkg/plugin/report/types.go
@@ -78,3 +78,8 @@ func (t templateData) VariableValues() string {
 func (t templateData) Theme() string {
 	return t.Conf.Theme
 }
+
+// IsHTMLFormat returns true if report format is HTML.
+func (t templateData) IsHTMLFormat() bool {
+	return t.Conf.ReportFormat == "html"
+}

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -69,6 +69,10 @@ func (app *App) updateConfig(req *http.Request, conf *plugin_config.Config) {
 		conf.DashboardMode = req.URL.Query().Get("dashboardMode")
 	}
 
+	if req.URL.Query().Has("format") {
+		conf.ReportFormat = req.URL.Query().Get("format")
+	}
+
 	if req.URL.Query().Has("timeZone") {
 		conf.TimeZone = req.URL.Query().Get("timeZone")
 	}

--- a/provisioning/plugins/app.yaml
+++ b/provisioning/plugins/app.yaml
@@ -126,6 +126,15 @@ apps:
       #
       logo: ''
 
+      # Report format.
+      #
+      # Format of the generated report. Currently supports HTML and PDF.
+      #
+      # This setting can be overridden for a particular dashboard by using query parameter
+      # ?format=pdf or ?format=html during report generation process
+      #
+      reportFormat: pdf
+
       # Header HTML template in the report.
       #
       # Custom HTML header template to be used in the report. If empty, default template

--- a/src/README.md
+++ b/src/README.md
@@ -286,6 +286,9 @@ as well to render the panels in that given time zone.
 The following settings are advanced settings that allow to customize the header and footer
 of the report using custom HTML templates.
 
+- `file:reportFormat; env:GF_REPORTER_PLUGIN_REPORT_FORMAT; ui:Report Format`:
+  Format of the generated report. Currently supports PDF and HTML. Default is PDF.
+
 - `file:headerTemplate; env:GF_REPORTER_PLUGIN_REPORT_HEADER_TEMPLATE; ui:Header Template`:
   HTML template that will be added as header to the report. Mutually exclusive with
   `headerTemplateFile`.

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -37,6 +37,7 @@ export type JsonData = {
   orientation?: string;
   layout?: string;
   dashboardMode?: string;
+  reportFormat?: string;
   timeZone?: string;
   timeFormat?: string;
   logo?: string;
@@ -84,6 +85,10 @@ type State = {
   dashboardMode: string;
   // If dashboardMode has changed
   dashboardModeChanged: boolean;
+  // reportFormat (pdf or html)
+  reportFormat: string;
+  // If reportFormat has changed
+  reportFormatChanged: boolean;
   // time zone in IANA format
   timeZone: string;
   // If timeZone has changed
@@ -162,6 +167,8 @@ export const AppConfig = ({ plugin }: Props) => {
     layoutChanged: false,
     dashboardMode: jsonData?.dashboardMode || "default",
     dashboardModeChanged: false,
+    reportFormat: jsonData?.reportFormat || "pdf",
+    reportFormatChanged: false,
     timeZone: jsonData?.timeZone || "",
     timeZoneChanged: false,
     timeFormat: jsonData?.timeFormat || "",
@@ -215,6 +222,11 @@ export const AppConfig = ({ plugin }: Props) => {
     { label: "Full", value: "full" },
   ];
 
+  const reportFormatOptions = [
+    { label: "PDF", value: "pdf" },
+    { label: "HTML", value: "html" },
+  ];
+
   const onChangeURL = (event: ChangeEvent<HTMLInputElement>) => {
     setState({
       ...state,
@@ -260,6 +272,14 @@ export const AppConfig = ({ plugin }: Props) => {
       ...state,
       dashboardMode: value,
       dashboardModeChanged: true,
+    });
+  };
+
+  const onChangeReportFormat = (value: string) => {
+    setState({
+      ...state,
+      reportFormat: value,
+      reportFormatChanged: true,
     });
   };
 
@@ -382,6 +402,7 @@ export const AppConfig = ({ plugin }: Props) => {
                     orientation: state.orientation,
                     layout: state.layout,
                     dashboardMode: state.dashboardMode,
+                    reportFormat: state.reportFormat,
                     timeZone: state.timeZone,
                     timeFormat: state.timeFormat,
                     logo: state.logo,
@@ -435,6 +456,7 @@ export const AppConfig = ({ plugin }: Props) => {
                     orientation: state.orientation,
                     layout: state.layout,
                     dashboardMode: state.dashboardMode,
+                    reportFormat: state.reportFormat,
                     timeZone: state.timeZone,
                     timeFormat: state.timeFormat,
                     logo: state.logo,
@@ -616,6 +638,20 @@ export const AppConfig = ({ plugin }: Props) => {
           isCollapsible
           isInitiallyOpen={false}
         >
+          {/* Report Format */}
+          <Field
+            label="Report Format"
+            description="Format of the dashboard report."
+            data-testid={testIds.appConfig.reportFormat}
+            className={s.marginTop}
+          >
+            <RadioButtonGroup
+              options={reportFormatOptions}
+              value={state.reportFormat}
+              onChange={onChangeReportFormat}
+            />
+          </Field>
+
           {/* Header Template */}
           <Field
             label="Report Header Template"
@@ -793,6 +829,7 @@ export const AppConfig = ({ plugin }: Props) => {
                 orientation: state.orientation,
                 layout: state.layout,
                 dashboardMode: state.dashboardMode,
+                reportFormat: state.reportFormat,
                 timeZone: state.timeZone,
                 timeFormat: state.timeFormat,
                 logo: state.logo,
@@ -828,6 +865,7 @@ export const AppConfig = ({ plugin }: Props) => {
               !state.layoutChanged &&
               !state.orientationChanged &&
               !state.dashboardModeChanged &&
+              !state.reportFormatChanged &&
               !state.timeZoneChanged &&
               !state.timeFormatChanged &&
               !state.logoChanged &&

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -8,6 +8,7 @@ export const testIds = {
     layout: "data-testid ac-layout",
     orientation: "data-testid ac-orientation",
     dashboardMode: "data-testid ac-dashboard-mode",
+    reportFormat: "data-testid ac-report-format",
     tz: "data-testid ac-timezone",
     tf: "data-testid ac-timeformat",
     logo: "data-testid ac-logo",


### PR DESCRIPTION
* Users will be able to configure globally or during report generation, the format of the report. Besides PDF, HTML reports are supported now.

Closes #559